### PR TITLE
Fixed bug in setter for required params

### DIFF
--- a/swagger-codegen-config.json
+++ b/swagger-codegen-config.json
@@ -1,4 +1,4 @@
 {
 	"packageName": "isi_sdk",
-	"packageVersion": "1.0.1"
+	"packageVersion": "1.0.2"
 }

--- a/swagger_templates/python/model.mustache
+++ b/swagger_templates/python/model.mustache
@@ -90,7 +90,7 @@ class {{classname}}(object):
 {{#hasValidation}}
 
 {{#required}}
-        if not {{name}}:
+        if {{name}} is None:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")
 {{/required}}
 {{#maxLength}}

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,15 +1,16 @@
 import isi_sdk
 import urllib3
+import test_constants
 
 urllib3.disable_warnings()
 
 # configure username and password
-isi_sdk.configuration.username = "root"
-isi_sdk.configuration.password = "a"
-isi_sdk.configuration.verify_ssl = False
+isi_sdk.configuration.username = test_constants.USERNAME
+isi_sdk.configuration.password = test_constants.PASSWORD
+isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
 # configure host
-host = "https://VNODE2294.west.isilon.com:8080"
+host = test_constants.HOST
 apiClient = isi_sdk.ApiClient(host)
 clusterApi = isi_sdk.ClusterApi(apiClient)
 

--- a/tests/test_event_eventgroup_ocurrences.py
+++ b/tests/test_event_eventgroup_ocurrences.py
@@ -1,15 +1,16 @@
 import isi_sdk
 import urllib3
+import test_constants
 
 urllib3.disable_warnings()
 
 # configure username and password
-isi_sdk.configuration.username = "root"
-isi_sdk.configuration.password = "a"
-isi_sdk.configuration.verify_ssl = False
+isi_sdk.configuration.username = test_constants.USERNAME
+isi_sdk.configuration.password = test_constants.PASSWORD
+isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
 # configure host
-host = "https://VNODE2294.west.isilon.com:8080"
+host = test_constants.HOST
 apiClient = isi_sdk.ApiClient(host)
 eventApi = isi_sdk.EventApi(apiClient)
 

--- a/tests/test_network_groupnets.py
+++ b/tests/test_network_groupnets.py
@@ -1,0 +1,28 @@
+import isi_sdk as isi_sdk
+from isi_sdk.rest import ApiException
+import urllib3
+import test_constants
+
+from pprint import pprint
+
+urllib3.disable_warnings()
+
+# configure username and password
+isi_sdk.configuration.username = test_constants.USERNAME
+isi_sdk.configuration.password = test_constants.PASSWORD
+isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
+
+# configure host
+host = test_constants.HOST
+api_client = isi_sdk.ApiClient(host)
+api_instance = isi_sdk.NetworkGroupnetsApi(api_client)
+
+try:
+
+    api_response = \
+            api_instance.list_subnets_subnet_pools('groupnet0', 'subnet0')
+    pprint(api_response)
+
+except ApiException as e:
+
+    print "Exception when calling list_subnets_subnet_pools: %s\n" % e

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -1,15 +1,16 @@
 import isi_sdk
 import urllib3
+import test_constants
 
 urllib3.disable_warnings()
 
 # configure username and password
-isi_sdk.configuration.username = "root"
-isi_sdk.configuration.password = "a"
-isi_sdk.configuration.verify_ssl = False
+isi_sdk.configuration.username = test_constants.USERNAME
+isi_sdk.configuration.password = test_constants.PASSWORD
+isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
 # configure host
-host = "https://VNODE2294.west.isilon.com:8080"
+host = test_constants.HOST
 apiClient = isi_sdk.ApiClient(host)
 quotaApi = isi_sdk.QuotaApi(apiClient)
 


### PR DESCRIPTION
The model.mustache template defines an if clause for parameters that
are required and have validation that looks like this:
```python
if not {{param}}:
    raise ValueError("Invalid value param is 'None'")
```

This part of the template was inherited from the upstream template,
the intention of the clause appears to be detect if the parameter is
being set to None. However, it causes issues for required parameters
that are of type 'integer' or 'float' because a value of 0 or 0.0
will be treated the same as the value of None, which is not correct.

This issue was encountered by an SE attempting to utilize the
NetworkGroupnetsApi.list_subnets_subnet_pools function, which prior to
this fix will throw an exception when the value of the sc_ttl parameter
is 0. I added the test script that I used to reproduce the issue and to
verify that the change fixes the issue. I also ran all the other test
scripts in the tests directory to verify that they all still worked.

Also, updated several of the tests to use test_constants.py.