### PR TITLE
Reverted templates to original versions.

### DIFF
--- a/swagger_templates/python/api.mustache
+++ b/swagger_templates/python/api.mustache
@@ -1,6 +1,21 @@
 # coding: utf-8
 
-{{>partial_header}}
+"""
+{{classname}}.py
+Copyright 2016 SmartBear Software
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
 
 from __future__ import absolute_import
 
@@ -54,40 +69,6 @@ class {{classname}}(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
 {{#allParams}}
-        :param {{dataType}} {{paramName}}: {{{description}}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
-{{/allParams}}
-        :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
-                 If the method is called asynchronously,
-                 returns the request thread.
-        """
-        kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
-            return self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)
-        else:
-            (data) = self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)
-            return data
-
-    def {{operationId}}_with_http_info(self, {{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs):
-        """
-        {{{summary}}}
-        {{{notes}}}
-
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-{{#sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}callback=callback_function)
-{{/sortParamsByRequiredFlag}}
-{{^sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}={{paramName}}_value, {{/required}}{{/allParams}}callback=callback_function)
-{{/sortParamsByRequiredFlag}}
-
-        :param callback function: The callback function
-            for asynchronous request. (optional)
-{{#allParams}}
         :param {{dataType}} {{paramName}}: {{{description}}}{{#required}} (required){{/required}}{{#optional}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/optional}}
 {{/allParams}}
         :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
@@ -97,7 +78,6 @@ class {{classname}}(object):
 
         all_params = [{{#allParams}}'{{paramName}}'{{#hasMore}}, {{/hasMore}}{{/allParams}}]
         all_params.append('callback')
-        all_params.append('_return_http_data_only')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -108,6 +88,7 @@ class {{classname}}(object):
                 )
             params[key] = val
         del params['kwargs']
+
 {{#allParams}}
 {{#required}}
         # verify the required parameter '{{paramName}}' is set
@@ -126,66 +107,52 @@ class {{classname}}(object):
 {{/vendorExtensions.x-isi-url-encode-path-param}}
 {{#hasValidation}}
     {{#maxLength}}
-        if '{{paramName}}' in params and len(params['{{paramName}}']) > {{maxLength}}:
+        if '{{paramName}}' in params and len(params['{{paramName}}']) > {{maxLength}}: 
             raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, length must be less than or equal to `{{maxLength}}`")
     {{/maxLength}}
     {{#minLength}}
-        if '{{paramName}}' in params and len(params['{{paramName}}']) < {{minLength}}:
+        if '{{paramName}}' in params and len(params['{{paramName}}']) < {{minLength}}: 
             raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, length must be greater than or equal to `{{minLength}}`")
     {{/minLength}}
     {{#maximum}}
-        if '{{paramName}}' in params and params['{{paramName}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}:
-            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must be a value less than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}`{{maximum}}`")
+        if '{{paramName}}' in params and params['{{paramName}}'] > {{maximum}}: 
+            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must be a value less than or equal to  `{{maximum}}`")
     {{/maximum}}
     {{#minimum}}
-        if '{{paramName}}' in params and params['{{paramName}}'] <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}:
-            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must be a value greater than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}`{{minimum}}`")
+        if '{{paramName}}' in params and params['{{paramName}}'] < {{minimum}}: 
+            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must be a value greater than or equal to `{{minimum}}`")
     {{/minimum}}
     {{#pattern}}
-        if '{{paramName}}' in params and not re.search('{{{vendorExtensions.x-regex}}}', params['{{paramName}}']{{#vendorExtensions.x-modifiers}}{{#-first}}, flags={{/-first}}re.{{.}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}}):
-            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must conform to the pattern `{{{pattern}}}`")
+        if '{{paramName}}' in params and not re.search('{{vendorExtensions.x-regex}}', params['{{paramName}}']{{#vendorExtensions.x-modifiers}}{{#-first}}, flags={{/-first}}re.{{.}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}}): 
+            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, must conform to the pattern `{{pattern}}`")
     {{/pattern}}
-    {{#maxItems}}
-        if '{{paramName}}' in params and len(params['{{paramName}}']) > {{maxItems}}:
-            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, number of items must be less than or equal to `{{maxItems}}`")
-    {{/maxItems}}
-    {{#minItems}}
-        if '{{paramName}}' in params and len(params['{{paramName}}']) < {{minItems}}:
-            raise ValueError("Invalid value for parameter `{{paramName}}` when calling `{{operationId}}`, number of items must be greater than or equal to `{{minItems}}`")
-    {{/minItems}}
 {{/hasValidation}}
 {{/allParams}}
-
-        collection_formats = {}
 
         resource_path = '{{path}}'.replace('{format}', 'json')
         path_params = {}
 {{#pathParams}}
         if '{{paramName}}' in params:
-            path_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
-            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
+            path_params['{{baseName}}'] = params['{{paramName}}']
 {{/pathParams}}
 
         query_params = {}
 {{#queryParams}}
         if '{{paramName}}' in params:
-            query_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
-            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
+            query_params['{{baseName}}'] = params['{{paramName}}']
 {{/queryParams}}
 
         header_params = {}
 {{#headerParams}}
         if '{{paramName}}' in params:
-            header_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
-            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
+            header_params['{{baseName}}'] = params['{{paramName}}']
 {{/headerParams}}
 
         form_params = []
         local_var_files = {}
 {{#formParams}}
         if '{{paramName}}' in params:
-            {{#notFile}}form_params.append(('{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}{{#isListContainer}}
-            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
+            {{#notFile}}form_params.append(('{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
 {{/formParams}}
 
         body_params = None
@@ -196,18 +163,18 @@ class {{classname}}(object):
 
         # HTTP header `Accept`
         header_params['Accept'] = self.api_client.\
-            select_header_accept([{{#produces}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/produces}}])
+            select_header_accept([{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([{{#consumes}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}])
+            select_header_content_type([{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}])
 
         # Authentication setting
         auth_settings = [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
 
-        return self.api_client.call_api(resource_path, '{{httpMethod}}',
+        response = self.api_client.call_api(resource_path, '{{httpMethod}}',
                                             path_params,
                                             query_params,
                                             header_params,
@@ -216,8 +183,7 @@ class {{classname}}(object):
                                             files=local_var_files,
                                             response_type={{#returnType}}'{{returnType}}'{{/returnType}}{{^returnType}}None{{/returnType}},
                                             auth_settings=auth_settings,
-                                            callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'),
-                                            collection_formats=collection_formats)
+                                            callback=params.get('callback'))
+        return response
 {{/operation}}
 {{/operations}}

--- a/swagger_templates/python/api_client.mustache
+++ b/swagger_templates/python/api_client.mustache
@@ -19,15 +19,17 @@ Copyright 2016 SmartBear Software
 """
 
 from __future__ import absolute_import
-
 from . import models
 from .rest import RESTClientObject
 from .rest import ApiException
 
 import os
 import re
+import sys
+import urllib
 import json
 import mimetypes
+import random
 import tempfile
 import threading
 
@@ -35,8 +37,14 @@ from datetime import datetime
 from datetime import date
 
 # python 2 and python 3 compatibility library
-from six import PY3, integer_types, iteritems, text_type
-from six.moves.urllib.parse import quote, quote_plus
+from six import iteritems
+
+try:
+    # for python3
+    from urllib.parse import quote, quote_plus
+except ImportError:
+    # for python2
+    from urllib import quote, quote_plus
 
 from .configuration import Configuration
 
@@ -74,6 +82,11 @@ class ApiClient(object):
         self.cookie = cookie
         # Set default User-Agent.
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{packageVersion}}}/python{{/httpUserAgent}}'
+        # This is used for detecting for the special case of a path parameter
+        # that is tagged with x-isi-url-encode-path-param (more details in the
+        # __call_api function).
+        self.quote_plus_tag = "__x-isi-url-encode-path-param__"
+        self.quote_plus_tag_len = len(self.quote_plus_tag)
 
     @property
     def user_agent(self):
@@ -95,55 +108,46 @@ class ApiClient(object):
     def __call_api(self, resource_path, method,
                    path_params=None, query_params=None, header_params=None,
                    body=None, post_params=None, files=None,
-                   response_type=None, auth_settings=None, callback=None,
-                   _return_http_data_only=None, collection_formats=None):
+                   response_type=None, auth_settings=None, callback=None):
 
-        # header parameters
+        # headers parameters
         header_params = header_params or {}
         header_params.update(self.default_headers)
         if self.cookie:
             header_params['Cookie'] = self.cookie
         if header_params:
             header_params = self.sanitize_for_serialization(header_params)
-            header_params = dict(self.parameters_to_tuples(header_params,
-                                                           collection_formats))
 
         # path parameters
         if path_params:
             path_params = self.sanitize_for_serialization(path_params)
-            path_params = self.parameters_to_tuples(path_params,
-                                                    collection_formats)
-            for k, v in path_params:
-                v_str = str(v)
+            for k, v in iteritems(path_params):
+                v_str = str(self.to_path_value(v))
                 # Check for the special case of the
                 # x-isi-url-encode-path-param, which indicates that the
                 # parameter should be encoded with quote_plus in order
                 # to encode the '/' character.
-                quote_plus_tag = "__x-isi-url-encode-path-param__"
-                tag_len = len(quote_plus_tag)
                 # check if the first part of v_str matches the tag
-                if v_str[:tag_len] == quote_plus_tag:
+                if v_str[:self.quote_plus_tag_len] == self.quote_plus_tag:
                     # remove "__x-isi-url-encode-path-param__"
-                    v_str = v_str[tag_len:]
+                    v_str = v_str[self.quote_plus_tag_len:]
                     # then url-encode with quote_plus
-                    resource_path = resource_path.replace(
-                        '{%s}' % k, quote_plus(v_str))
+                    replacement = quote_plus(v_str)
                 else:
-                    resource_path = resource_path.replace(
-                        '{%s}' % k, quote(v_str))
+                    replacement = quote(v_str)
+                resource_path = resource_path.\
+                    replace('{' + k + '}', replacement)
 
         # query parameters
         if query_params:
             query_params = self.sanitize_for_serialization(query_params)
-            query_params = self.parameters_to_tuples(query_params,
-                                                     collection_formats)
+            query_params = {k: self.to_path_value(v)
+                            for k, v in iteritems(query_params)}
 
         # post parameters
         if post_params or files:
             post_params = self.prepare_post_parameters(post_params, files)
             post_params = self.sanitize_for_serialization(post_params)
-            post_params = self.parameters_to_tuples(post_params,
-                                                    collection_formats)
 
         # auth setting
         self.update_params_for_auth(header_params, query_params, auth_settings)
@@ -170,18 +174,30 @@ class ApiClient(object):
             deserialized_data = None
 
         if callback:
-            callback(deserialized_data) if _return_http_data_only else callback((deserialized_data, response_data.status, response_data.getheaders()))
-        elif _return_http_data_only:
-            return (deserialized_data)
+            callback(deserialized_data)
         else:
-            return (deserialized_data, response_data.status, response_data.getheaders())
+            return deserialized_data
+
+    def to_path_value(self, obj):
+        """
+        Takes value and turn it into a string suitable for inclusion in
+        the path, by url-encoding.
+
+        :param obj: object or string value.
+
+        :return string: quoted value.
+        """
+        if type(obj) == list:
+            return ','.join(obj)
+        else:
+            return str(obj)
 
     def sanitize_for_serialization(self, obj):
         """
         Builds a JSON POST object.
 
         If obj is None, return None.
-        If obj is str, int, long, float, bool, return directly.
+        If obj is str, int, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is list, sanitize each element in the list.
@@ -191,7 +207,9 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, float, bool, tuple) + tuple(integer_types) + (text_type,)
+        types = (str, int, float, bool, tuple)
+        if sys.version_info < (3,0):
+            types = types + (unicode,)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
@@ -223,7 +241,7 @@ class ApiClient(object):
 
         :param response: RESTResponse object to be deserialized.
         :param response_type: class literal for
-            deserialized object, or string of class name.
+            deserialzied object, or string of class name.
 
         :return: deserialized object.
         """
@@ -268,13 +286,11 @@ class ApiClient(object):
             if klass in ['int', 'float', 'str', 'bool',
                          "date", 'datetime', "object"]:
                 klass = eval(klass)
-            elif klass == 'long':
-                klass = int if PY3 else long
             # for model types
             else:
                 klass = eval('models.' + klass)
 
-        if klass in integer_types or klass in (float, str, bool):
+        if klass in [int, float, str, bool]:
             return self.__deserialize_primitive(data, klass)
         elif klass == object:
             return self.__deserialize_object(data)
@@ -288,8 +304,7 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, callback=None,
-                 _return_http_data_only=None, collection_formats=None):
+                 response_type=None, auth_settings=None, callback=None):
         """
         Makes the HTTP request (synchronous) and return the deserialized data.
         To make an async request, define a function for callback.
@@ -310,9 +325,6 @@ class ApiClient(object):
         :param callback function: Callback function for asynchronous request.
             If provide this parameter,
             the request will be called asynchronously.
-        :param _return_http_data_only: response data without head status code and headers
-        :param collection_formats: dict of collection formats for path, query,
-            header, and post parameters.
         :return:
             If provide parameter callback,
             the request will be called asynchronously.
@@ -324,8 +336,7 @@ class ApiClient(object):
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
-                                   response_type, auth_settings, callback,
-                                   _return_http_data_only, collection_formats)
+                                   response_type, auth_settings, callback)
         else:
             thread = threading.Thread(target=self.__call_api,
                                       args=(resource_path, method,
@@ -333,8 +344,7 @@ class ApiClient(object):
                                             header_params, body,
                                             post_params, files,
                                             response_type, auth_settings,
-                                            callback, _return_http_data_only,
-                                            collection_formats))
+                                            callback))
         thread.start()
         return thread
 
@@ -382,40 +392,9 @@ class ApiClient(object):
                                            body=body)
         else:
             raise ValueError(
-                "http method must be `GET`, `HEAD`, `OPTIONS`,"
+                "http method must be `GET`, `HEAD`,"
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
-
-    def parameters_to_tuples(self, params, collection_formats):
-        """
-        Get parameters as list of tuples, formatting collections.
-
-        :param params: Parameters as dict or list of two-tuples
-        :param dict collection_formats: Parameter collection formats
-        :return: Parameters as list of tuples, collections formatted
-        """
-        new_params = []
-        if collection_formats is None:
-            collection_formats = {}
-        for k, v in iteritems(params) if isinstance(params, dict) else params:
-            if k in collection_formats:
-                collection_format = collection_formats[k]
-                if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
-                else:
-                    if collection_format == 'ssv':
-                        delimiter = ' '
-                    elif collection_format == 'tsv':
-                        delimiter = '\t'
-                    elif collection_format == 'pipes':
-                        delimiter = '|'
-                    else:  # csv is the default
-                        delimiter = ','
-                    new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
-            else:
-                new_params.append((k, v))
-        return new_params
 
     def prepare_post_parameters(self, post_params=None, files=None):
         """
@@ -484,7 +463,7 @@ class ApiClient(object):
         Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
-        :param querys: Query parameters tuple list to be updated.
+        :param querys: Query parameters dict to be updated.
         :param auth_settings: Authentication setting identifiers list.
         """
         config = Configuration()
@@ -500,7 +479,7 @@ class ApiClient(object):
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
+                    querys[auth_setting['key']] = auth_setting['value']
                 else:
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'
@@ -539,7 +518,7 @@ class ApiClient(object):
         :param data: str.
         :param klass: class literal.
 
-        :return: int, long, float, str, bool.
+        :return: int, float, str, bool.
         """
         try:
             value = klass(data)
@@ -606,9 +585,6 @@ class ApiClient(object):
         :return: model object.
         """
         instance = klass()
-
-        if not instance.swagger_types:
-            return data
 
         for attr, attr_type in iteritems(instance.swagger_types):
             if data is not None \

--- a/swagger_templates/python/model.mustache
+++ b/swagger_templates/python/model.mustache
@@ -75,35 +75,6 @@ class {{classname}}(object):
         :type: {{datatype}}
         """
         {{#isEnum}}allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]
-{{#isContainer}}
-{{#isListContainer}}
-{{#required}}
-        if not set({{{name}}}).issubset(set(allowed_values)):
-{{/required}}
-{{^required}}
-        if {{name}} is not None and not set({{{name}}}).issubset(set(allowed_values)):
-{{/required}}
-            raise ValueError(
-                "Invalid values for `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}})-set(allowed_values))), 
-                        ", ".join(map(str, allowed_values)))
-            )
-{{/isListContainer}}
-{{#isMapContainer}}
-{{#required}}
-        if not set({{{name}}}.keys()).issubset(set(allowed_values)):
-{{/required}}
-{{^required}}
-        if {{name}} is not None and not set({{{name}}}.keys()).issubset(set(allowed_values)):
-{{/required}}
-            raise ValueError(
-                "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}}.keys())-set(allowed_values))), 
-                        ", ".join(map(str, allowed_values)))
-            )
-{{/isMapContainer}}
-{{/isContainer}}
-{{^isContainer}}
 {{#required}}
         if {{name}} not in allowed_values:
 {{/required}}
@@ -114,7 +85,6 @@ class {{classname}}(object):
                 "Invalid value for `{{name}}`, must be one of {0}"
                 .format(allowed_values)
             )
-{{/isContainer}}
 {{/isEnum}}
 {{^isEnum}}
 {{#hasValidation}}


### PR DESCRIPTION
I mistakenly used the templates from the latest version of Swagger
Codegen for my last commit, which ended up breaking things. So these are
the same changes on the templates to fix the /nfs/aliases/<AID> end
point, but applied to the version of the templates that we use in our
build (1939ce8e91f9de4a35ba3d90fd99a28f41c5035c).