### PR TITLE
Fix handling of long ints in Python2

### DIFF
--- a/swagger_templates/python/api_client.mustache
+++ b/swagger_templates/python/api_client.mustache
@@ -46,6 +46,14 @@ except ImportError:
     # for python2
     from urllib import quote, quote_plus
 
+# special handling of `long` (python2 only)
+try:
+    # Python 2
+    long
+except NameError:
+    # Python 3
+    long = int
+
 from .configuration import Configuration
 
 
@@ -197,7 +205,7 @@ class ApiClient(object):
         Builds a JSON POST object.
 
         If obj is None, return None.
-        If obj is str, int, float, bool, return directly.
+        If obj is str, int, long, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is list, sanitize each element in the list.
@@ -207,7 +215,7 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, int, float, bool, tuple)
+        types = (str, int, long, float, bool, tuple)
         if sys.version_info < (3,0):
             types = types + (unicode,)
         if isinstance(obj, type(None)):
@@ -283,14 +291,14 @@ class ApiClient(object):
 
             # convert str to class
             # for native types
-            if klass in ['int', 'float', 'str', 'bool',
+            if klass in ['int', 'long', 'float', 'str', 'bool',
                          "date", 'datetime', "object"]:
                 klass = eval(klass)
             # for model types
             else:
                 klass = eval('models.' + klass)
 
-        if klass in [int, float, str, bool]:
+        if klass in [int, long, float, str, bool]:
             return self.__deserialize_primitive(data, klass)
         elif klass == object:
             return self.__deserialize_object(data)
@@ -518,7 +526,7 @@ class ApiClient(object):
         :param data: str.
         :param klass: class literal.
 
-        :return: int, float, str, bool.
+        :return: int, long, float, str, bool.
         """
         try:
             value = klass(data)


### PR DESCRIPTION
Cherry pick the minimal upstream code changes from
swagger-api/swagger-codegen:
6c350a7d2d097d6c98558e60149d8763b8823868
and
89befeb45b86905937e91a20880b1c36537db26e

Fixes issue #32 
