### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ See the generated packages on PyPI for example code:
 
 The most up-to-date documentation for the language bindings is included in the root directory of your downloaded release package (or of your own generated bindings if you've generated your own using the instructions at [readme.dev.md](readme.dev.md)).  It is a set of markdown files starting with the README.md in the root directory of the package.
 
-We intend to also publish online docs as part of the build process for this repo's releases, but we haven't finished setting that up yet.  Meanwhile, if you really need online docs, some are still available at the legacy bindings repos linked below, but these will gradually be going out of sync with the latest bindings releases in this repo.
-
-- [Legacy 8.0 Bindings Docs](https://github.com/Isilon/isilon_sdk_8_0_python)
-
-- [Legacy 7.2 Bindings Docs](https://github.com/Isilon/isilon_sdk_7_2_python)
-
 ### Other Isilon SDK and API links:
 
 * For OneFS API reference documents, discussions, and blog posts, refer to the [Isilon SDK Info Hub](https://community.emc.com/docs/DOC-48273).

--- a/readme.dev.md
+++ b/readme.dev.md
@@ -15,6 +15,8 @@ The walkthrough below will guide you through the generation process step by step
 2. Find a OneFS cluster, get the IP address.
 3. Run `python components/create_swagger_config.py -i <cluster-ip-address> -o <output_file> --username <username> --password <password>` <br> if you omit --username or --password then it will prompt you
 
+**Note:** An endpoint exclude file must be specified when using a OneFS 7.2 cluster for generation of the bindings. Add `-e excluded_end_points_7_2.json`to the above command. The file excluded_end_points_7_2.json can be found in the root of this repository.
+
 This will automatically generate a swagger config `<output_file>` based on the ?describe responses from the PAPI handlers on your node.  Swagger tools can now use this config to create language bindings and documentation.
 
 ### To generate PAPI bindings for Python or other languages using the swagger config:


### PR DESCRIPTION
* Removes the links to the deprecated online docs in favor of the docs shipped inside the release
* Adds a note to the dev readme about using endpoint exclude files for OneFS 7.2 SDK generation