### PR TITLE
OneFS 8.1.0 Freight Trains support

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -238,13 +238,14 @@ def IsiSchemaToSwaggerObjectDefs(
             if "type" not in schemaListItem:
                 # hack - just return empty object
                 return "#/definitions/Empty"
-            # use the first single object schema (usually the "list" type) is
-            # used to allow for multiple items to be created with a single
-            # call.
+            # As of OneFS 8.1.0, the response body schema may be a list where
+            # the first object in the list is the errors object and the second
+            # object in the list is the success object. Thus, this loop will
+            # iterate until it has assigned the properties from the last
+            # object in the list.
             if schemaListItem["type"] == "object":
                 isiSchema["type"] = "object"
                 isiSchema["properties"] = schemaListItem["properties"]
-                break
 
     if isiSchema["type"] != "object":
         raise RuntimeError("Isi Schema is not type 'object': "\


### PR DESCRIPTION
In the following example POST response body schema, the properties will be pulled from the success object rather than the errors object: 
```
POST response body schema:
{
  "type": [
    {
      "additionalProperties": false, 
      "type": "object", 
      "description": "A list of errors that may be returned.", 
      "properties": {
        "errors": {
          "items": {
            "additionalProperties": false, 
            "type": "object", 
            "description": "An object describing a single error.", 
            "properties": {
              "field": {
                "type": "string", 
                "description": "The field with the error if applicable."
              }, 
              "message": {
                "type": "string", 
                "description": "The error message."
              }, 
              "code": {
                "type": "string", 
                "description": "The error code."
              }
            }
          }, 
          "type": "array"
        }
      }
    }, 
    {
      "type": "object", 
      "properties": {
        "id": {
          "minLength": 0, 
          "required": true, 
          "type": "string", 
          "description": "ID of created item that can be used to refer to item in the collection-item resource path.", 
          "maxLength": 255
        }
      }
    }
  ]
}
```