### PR TITLE
Additional Swagger properties for OneFS 8.1.0 support

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -19,7 +19,7 @@ requests.packages.urllib3.disable_warnings()
 
 k_swaggerParamIsiPropCommonFields = [
     "description", "required", "type", "default", "maximum", "minimum", "enum",
-    "items"]
+    "items", "maxLength", "minLength", "pattern"]
 
 # list of url parameters that need to be url encoded, this hack works for now,
 # but could cause problems if new params are added that are not unique.
@@ -56,6 +56,11 @@ def IsiPropsToSwaggerParams(isiProps, paramType):
                 print >> sys.stderr, "WARNING: " + fieldName + " not " \
                         "defined for Swagger in prop: " + str(isiProp)
                 continue
+            if fieldName == "pattern":
+                # XXX: bkrueger (27 Feb 2018) - Remove after upgrading
+                # Swagger from 2.2 to 2.3
+                # wrap with '/' to conform to Perl regex conventions
+                isiProp["pattern"] = '/' + isiProp["pattern"] + '/'
             if fieldName == "type":
                 if isiProp[fieldName] == "int":
                     # HACK fix for bugs in the PAPI

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -73,16 +73,39 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             csc.ParsePathParams(PATHS[3]),
             [])
 
+    def test_IsiPropsToSwaggerParams(self):
+        """Pattern is wrapped with forward slashes."""
+        isi_props = {
+            'licenses_to_include': {
+                'description': 'Licenses to include in activation file.',
+                'maxLength': 2500,
+                'minLength': 1,
+                'pattern': '.+',
+                'type': 'string'
+            }
+        }
+        actual = csc.IsiPropsToSwaggerParams(isi_props, 'query')
+
+        expected = [{
+            'description': 'Licenses to include in activation file.',
+            'pattern': '/.+/',
+            'in': 'query',
+            'minLength': 1,
+            'maxLength': 2500,
+            'type': 'string',
+            'name': 'licenses_to_include'
+        }]
+        self.assertEqual(actual, expected)
+
+
 if __name__ == '__main__':
     if __package__ is None:
         import sys
         from os import path
-        # Append swagger-config-generator root directory. 
+        # Append swagger-config-generator root directory.
         sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
         from components import create_swagger_config as csc
-        from components import papi_swagger_obj_defs_builder as odb
         unittest.main()
     else:
         from ..components import create_swagger_config as csc
-        from ..components import papi_swagger_obj_defs_builder as odb
         unittest.main()


### PR DESCRIPTION
OneFS 8.1.0 introduced the properties `maxLength`, `minLength`, and `pattern` to its JSON schemas. Thus, this PR adds them to the common fields list since these properties are supported as Swagger parameters.