### PR TITLE
Resolve Swagger spec validation issues

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -325,7 +325,7 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
                 prop['items']['enum'] = (
                     list(OrderedDict.fromkeys(prop['items']['enum'])))
         # Issue #10: Update required attribute to draft 4 style
-        elif (sub_obj_namespace.startswith('JobJob') and 'items' in prop and
+        elif (sub_obj_namespace.startswith('Job') and 'items' in prop and
               'required' in prop['items']):
             if prop['items']['required']:
                 if (is_response_object is False or
@@ -341,12 +341,14 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if 'descriprion' in prop:
                 prop['description'] = prop['descriprion']
                 del prop['descriprion']
-        elif (sub_obj_namespace.startswith('HealthcheckEvaluation') and
-              prop_name == 'run_status'):
-            if 'desciption' in prop:
+        elif sub_obj_namespace.startswith('HealthcheckEvaluation'):
+            if prop_name == 'run_status' and 'desciption' in prop:
                 prop['description'] = prop['desciption']
                 del prop['desciption']
-
+        elif 'Subnet' in sub_obj_namespace:
+            if prop_name == 'sc_service_name' and 'description:' in prop:
+                prop['description'] = prop['description:']
+                del prop['description:']
         # Issue #14: Include hardware `devices` fields
         elif sub_obj_namespace == 'HardwareTapes' and prop_name == 'devices':
             if 'media_changers' in prop and 'tapes' in prop:
@@ -369,6 +371,12 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if 'type' in prop['items']:
                 prop['items'] = prop['items']['type'].copy()
                 prop['type'] = 'array'
+        # Remove custom `ignore_case` field
+        elif sub_obj_namespace.startswith('EventAlertCondition'):
+            if 'ignore_case' in prop:
+                del prop['ignore_case']
+            if 'items' in prop and 'ignore_case' in prop['items']:
+                del prop['items']['ignore_case']
 
         if 'type' not in prop:
             if 'enum' in prop:

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -301,6 +301,12 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
                 isi_schema['required'] = True
             isi_schema['properties']['operation'] = operations.copy()
             del isi_schema['properties']['operations']
+    elif (sub_obj_namespace.startswith('StoragepoolNodepool') or
+          sub_obj_namespace.startswith('StoragepoolStoragepool')):
+        if 'health_flags' in isi_schema:
+            isi_schema['properties']['health_flags'] = \
+                isi_schema['health_flags']
+            del isi_schema['health_flags']
 
     required_props = []
     for prop_name, prop in isi_schema['properties'].items():
@@ -551,12 +557,14 @@ def find_or_add_obj_def(new_obj_def, new_obj_name,
             unique_props = {}
             unique_required = new_obj_def.get('required', [])
             for prop_name in new_obj_def['properties']:
-                # delete properties that are shared.
-                if prop_name not in existing_props:
-                    unique_props[prop_name] = \
-                        new_obj_def['properties'][prop_name]
                 if prop_name in existing_required:
                     unique_required.remove(prop_name)
+                # delete properties that are shared and not required
+                if prop_name not in existing_props or (
+                        prop_name in existing_props and
+                        prop_name in unique_required):
+                    unique_props[prop_name] = \
+                        new_obj_def['properties'][prop_name]
             new_obj_def['properties'] = unique_props
             extended_obj_def['allOf'].append(new_obj_def)
         else:
@@ -1223,10 +1231,9 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/5/healthcheck/checklists', u'/5/healthcheck/checklists/<ID>'),
-            (u'/5/healthcheck/evaluations', u'/5/healthcheck/evaluations/<ID>'),
-            (u'/5/healthcheck/items', u'/5/healthcheck/items/<ID>'),
-            (u'/5/healthcheck/parameters', u'/5/healthcheck/parameters/<ID>')
+            (u'/3/storagepool/nodepools', u'/3/storagepool/nodepools/<NID>'),
+            (u'/3/storagepool/storagepools', None),
+            (None, u'/3/storagepool/suggested-protection/<NID>'),
         ]
 
     success_count = 0

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -951,6 +951,11 @@ def isi_item_to_swagger_path(isi_api_name, isi_obj_name_space, isi_obj_name,
         if one_obj_name[-2:] == 'Id':
             swagger_path['post']['operationId'] = \
                 operation + isi_obj_name_space + one_obj_name[:-2] + 'ById'
+        # Issue #11: add the item-id as a url path parameter
+        post_id_param = item_id_param.copy()
+        post_id_param['description'] = isi_post_args['description']
+        swagger_path['post']['parameters'].append(post_id_param)
+
         add_path_params(swagger_path['post']['parameters'], extra_path_params)
 
     return item_id_url, swagger_path
@@ -1104,7 +1109,7 @@ def main():
     swagger_json = {
         'swagger': '2.0',
         'info': {
-            'version': '1.0.0',
+            'version': '0.1.11',
             'title': 'Isilon SDK',
             'description': 'Isilon SDK - Language bindings for the OneFS API',
             'termsOfService': ('https://github.com/emccode/'
@@ -1212,14 +1217,16 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/3/hardware/tapes', None)]
+            (u'/1/auth/mapping/identities',
+             u'/1/auth/mapping/identities/<SOURCE>'),
+        ]
 
     success_count = 0
     fail_count = 0
     object_defs = swagger_json['definitions']
-    for end_pointTuple in end_point_paths:
-        base_end_point_path = end_pointTuple[0]
-        item_end_point_path = end_pointTuple[1]
+    for end_point_tuple in end_point_paths:
+        base_end_point_path = end_point_tuple[0]
+        item_end_point_path = end_point_tuple[1]
         if base_end_point_path is None:
             tmp_base_endpoint_path = to_swagger_end_point(
                 os.path.dirname(item_end_point_path))

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -354,6 +354,13 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
                 }
                 del prop['media_changers']
                 del prop['tapes']
+        # Issue #15: Correct nested array schema
+        elif (sub_obj_namespace == (
+                'EventEventgroupOccurrencesEventgroup-Occurrence') and
+              prop_name == 'causes'):
+            if 'type' in prop['items']:
+                prop['items'] = prop['items']['type'].copy()
+                prop['type'] = 'array'
 
         if 'type' not in prop:
             if 'enum' in prop:
@@ -1217,8 +1224,8 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/1/auth/mapping/identities',
-             u'/1/auth/mapping/identities/<SOURCE>'),
+            (u'/3/event/eventgroup-occurrences',
+             u'/3/event/eventgroup-occurrences/<ID>'),
         ]
 
     success_count = 0

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -240,10 +240,10 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
         if 'properties' not in isi_schema and 'settings' not in isi_schema:
             print(('*** Invalid empty schema for object {}. '
                    "Adding 'properties' and 'type'.").format(isi_obj_name))
-            schemaCopy = isi_schema.copy()
+            schema_copy = isi_schema.copy()
             for key in isi_schema.keys():
                 del isi_schema[key]
-            isi_schema['properties'] = schemaCopy
+            isi_schema['properties'] = schema_copy
         else:
             print(("*** Invalid schema for object {}, no 'type' specified. "
                    "Adding 'type': 'object'.").format(isi_obj_name))
@@ -335,6 +335,12 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if 'descriprion' in prop:
                 prop['description'] = prop['descriprion']
                 del prop['descriprion']
+        elif (sub_obj_namespace.startswith('HealthcheckEvaluation') and
+              prop_name == 'run_status'):
+            if 'desciption' in prop:
+                prop['description'] = prop['desciption']
+                del prop['desciption']
+
         # Issue #14: Include hardware `devices` fields
         elif sub_obj_namespace == 'HardwareTapes' and prop_name == 'devices':
             if 'media_changers' in prop and 'tapes' in prop:
@@ -1217,8 +1223,10 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/3/event/eventgroup-occurrences',
-             u'/3/event/eventgroup-occurrences/<ID>'),
+            (u'/5/healthcheck/checklists', u'/5/healthcheck/checklists/<ID>'),
+            (u'/5/healthcheck/evaluations', u'/5/healthcheck/evaluations/<ID>'),
+            (u'/5/healthcheck/items', u'/5/healthcheck/items/<ID>'),
+            (u'/5/healthcheck/parameters', u'/5/healthcheck/parameters/<ID>')
         ]
 
     success_count = 0

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -59,13 +59,13 @@ def isi_props_to_swagger_params(isi_props, param_type):
     if not isi_props:
         return []
     swagger_parameters = []
-    for isi_prop_name, isi_prop in isi_props.iteritems():
+    for isi_prop_name, isi_prop in isi_props.items():
         # build a swagger param for each isi property
         swagger_param = {}
         swagger_param['in'] = param_type
         swagger_param['name'] = isi_prop_name
         # attach common fields
-        for field_name in isi_prop.keys():
+        for field_name in isi_prop:
             if field_name not in SWAGGER_PARAM_ISI_PROP_COMMON_FIELDS:
                 print('WARNING: {} not defined for Swagger in prop: {}'.format(
                     field_name, isi_prop))
@@ -241,7 +241,7 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             print(('*** Invalid empty schema for object {}. '
                    "Adding 'properties' and 'type'.").format(isi_obj_name))
             schema_copy = isi_schema.copy()
-            for key in isi_schema.keys():
+            for key in isi_schema:
                 del isi_schema[key]
             isi_schema['properties'] = schema_copy
         else:
@@ -303,7 +303,7 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             del isi_schema['properties']['operations']
 
     required_props = []
-    for prop_name, prop in isi_schema['properties'].iteritems():
+    for prop_name, prop in isi_schema['properties'].items():
 
         # Issue #8: Remove invalid placement of required field
         if (sub_obj_namespace == 'StoragepoolStatusUnhealthyItem' and
@@ -507,7 +507,7 @@ def find_or_add_obj_def(new_obj_def, new_obj_name,
     Return the 'definitions' path.
     """
     extended_obj_name = new_obj_name
-    for obj_name in SWAGGER_DEFS.keys():
+    for obj_name in SWAGGER_DEFS:
         existing_obj_def = get_object_def(obj_name)
         if new_obj_def['properties'] == existing_obj_def['properties']:
             if sorted(new_obj_def.get('required', [])) == \
@@ -533,7 +533,7 @@ def find_or_add_obj_def(new_obj_def, new_obj_name,
         existing_props = existing_obj['properties']
         existing_required = existing_obj.get('required', [])
 
-        for prop_name, prop in existing_props.iteritems():
+        for prop_name, prop in existing_props.items():
             if prop_name not in new_obj_def['properties']:
                 is_extension = False
                 break
@@ -550,7 +550,7 @@ def find_or_add_obj_def(new_obj_def, new_obj_name,
             }
             unique_props = {}
             unique_required = new_obj_def.get('required', [])
-            for prop_name in new_obj_def['properties'].keys():
+            for prop_name in new_obj_def['properties']:
                 # delete properties that are shared.
                 if prop_name not in existing_props:
                     unique_props[prop_name] = \

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -339,6 +339,21 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if 'descriprion' in prop:
                 prop['description'] = prop['descriprion']
                 del prop['descriprion']
+        # Issue #14: Include hardware `devices` fields
+        elif sub_obj_namespace == 'HardwareTapes' and prop_name == 'devices':
+            if 'media_changers' in prop and 'tapes' in prop:
+                prop['type'] = 'object'
+                prop['description'] = 'Information of Tape/MC device'
+                prop['properties'] = {
+                    'media_changers': {
+                        'items': prop['media_changers'].copy()
+                    },
+                    'tapes': {
+                        'items': prop['tapes'].copy()
+                    }
+                }
+                del prop['media_changers']
+                del prop['tapes']
 
         if 'type' not in prop:
             if 'enum' in prop:
@@ -1197,7 +1212,7 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/3/statistics/operations', None)]
+            (u'/3/hardware/tapes', None)]
 
     success_count = 0
     fail_count = 0

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -409,11 +409,6 @@ class TestCreateSwaggerConfig(unittest.TestCase):
                 'type': 'array'
             },
             'properties': {
-                'can_enable_l3': {
-                    'description': 'Indicates if enabling L3 is possible.',
-                    'required': True,
-                    'type': 'boolean'
-                },
                 'id': {
                     'description': 'The system ID given to the node pool.',
                     'required': True,
@@ -443,16 +438,12 @@ class TestCreateSwaggerConfig(unittest.TestCase):
                     'type': 'array',
                     'description': 'An array of containing health issues.'
                 },
-                'can_enable_l3': {
-                    'type': 'boolean',
-                    'description': 'Indicates if enabling L3 is possible.'
-                },
                 'id': {
                     'type': 'integer',
                     'description': 'The system ID given to the node pool.'
                 }
             },
-            'required': ['can_enable_l3', 'id'],
+            'required': ['id'],
             'type': 'object',
         }
         self.assertEqual(isi_schema, expected)

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -390,6 +390,73 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         }
         self.assertEqual(isi_schema, expected)
 
+    def test_move_health_flags_property(self):
+        """Move health flags from schema into properties."""
+        isi_schema = {
+            'description': 'Indicates if enabling L3 is possible.',
+            'health_flags': {
+                'description': 'An array of containing health issues.',
+                'items': {
+                    'enum': [
+                        'underprovisioned',
+                        'missing_drives',
+                        'devices_down',
+                        'devices_smartfailed',
+                        'waiting_repair'
+                    ],
+                    'type': 'string'
+                },
+                'type': 'array'
+            },
+            'properties': {
+                'can_enable_l3': {
+                    'description': 'Indicates if enabling L3 is possible.',
+                    'required': True,
+                    'type': 'boolean'
+                },
+                'id': {
+                    'description': 'The system ID given to the node pool.',
+                    'required': True,
+                    'type': 'integer'
+                },
+            },
+            'type': 'object'
+        }
+        csc.isi_schema_to_swagger_object(
+            'Storagepool', 'Nodepool',
+            isi_schema, 'Extended')
+
+        expected = {
+            'description': 'Indicates if enabling L3 is possible.',
+            'properties': {
+                'health_flags': {
+                    'items': {
+                        'enum': [
+                            'underprovisioned',
+                            'missing_drives',
+                            'devices_down',
+                            'devices_smartfailed',
+                            'waiting_repair'
+                        ],
+                        'type': 'string'
+                    },
+                    'type': 'array',
+                    'description': 'An array of containing health issues.'
+                },
+                'can_enable_l3': {
+                    'type': 'boolean',
+                    'description': 'Indicates if enabling L3 is possible.'
+                },
+                'id': {
+                    'type': 'integer',
+                    'description': 'The system ID given to the node pool.'
+                }
+            },
+            'required': ['can_enable_l3', 'id'],
+            'type': 'object',
+        }
+        self.assertEqual(isi_schema, expected)
+
 
 if __name__ == '__main__':
     if __package__ is None:

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -125,7 +125,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         del expected['properties']['health_flags']['items']['required']
 
         csc.isi_schema_to_swagger_object(
-            'StoragepoolStatus', 'UnhealthyItem', isi_schema, {},
+            'StoragepoolStatus', 'UnhealthyItem', isi_schema,
             'Extended', is_response_object=True)
 
         self.assertEqual(isi_schema, expected)
@@ -167,7 +167,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
 
         csc.isi_schema_to_swagger_object(
             'SmbSettingsGlobalSettings', 'AuditGlobalSaclItem', isi_schema,
-            {}, 'Extended', is_response_object=True)
+            'Extended', is_response_object=True)
 
         self.assertEqual(isi_schema, expected)
 
@@ -192,7 +192,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         expected['required'] = ['disconnected_nodes']
 
         csc.isi_schema_to_swagger_object(
-            'JobJob', 'Summary', isi_schema, {},
+            'JobJob', 'Summary', isi_schema,
             'Extended', is_response_object=True)
 
         self.assertEqual(isi_schema, expected)
@@ -234,7 +234,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             }
         }
         csc.isi_schema_to_swagger_object(
-            'DebugStats', 'Stats', isi_schema, {},
+            'DebugStats', 'Stats', isi_schema,
             'Extended', is_response_object=True)
 
         self.assertEqual(isi_schema, expected)
@@ -260,7 +260,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             'type': 'object'
         }
         csc.isi_schema_to_swagger_object(
-            'AuthAccess', 'AccessItem', isi_schema, {},
+            'AuthAccess', 'AccessItem', isi_schema,
             'Extended', is_response_object=True)
 
         self.assertEqual(isi_schema, expected)
@@ -280,7 +280,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             }
         }
         csc.isi_schema_to_swagger_object(
-            'Statistics', 'Operation', isi_schema, {},
+            'Statistics', 'Operation', isi_schema,
             'Extended', is_response_object=True)
 
         expected = {
@@ -330,7 +330,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             'type': 'object'
         }
         csc.isi_schema_to_swagger_object(
-            'Hardware', 'Tapes', isi_schema, {}, 'Extended')
+            'Hardware', 'Tapes', isi_schema, 'Extended')
 
         expected = {
             'description': 'Get list Tape and Changer devices',
@@ -372,7 +372,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         }
         csc.isi_schema_to_swagger_object(
             'EventEventgroupOccurrences', 'Eventgroup-Occurrence',
-            isi_schema, {}, 'Extended')
+            isi_schema, 'Extended')
 
         expected = {
             'properties': {

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -295,6 +295,63 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         }
         self.assertEqual(isi_schema, expected)
 
+    def test_invalid_sub_properties(self):
+        """Move sub properties under properties."""
+        isi_schema = {
+            'description': 'Get list Tape and Changer devices',
+            'properties': {
+                'devices': {
+                    'media_changers': {
+                        'properties': {
+                            'id': {
+                                'description': 'Unique display id.',
+                                'type': 'string'
+                            }
+                        },
+                        'type': 'array'
+                    },
+                    'tapes': {
+                        'properties': {
+                            'serial': {
+                                'description': 'Serial number',
+                                'type': 'string'
+                            }
+                        },
+                        'type': 'array'}},
+                'resume': {
+                    'description': 'Resume string returned by previous query.',
+                    'type': 'string'
+                },
+                'total': {
+                    'description': 'The number of devices',
+                    'type': 'integer'
+                }
+            },
+            'type': 'object'
+        }
+        csc.isi_schema_to_swagger_object(
+            'Hardware', 'Tapes', isi_schema, {}, 'Extended')
+
+        expected = {
+            'description': 'Get list Tape and Changer devices',
+            'properties': {
+                'devices': {
+                    '$ref': '#/definitions/HardwareTapesDevices',
+                    'description': 'Information of Tape/MC device'
+                },
+                'resume': {
+                    'description': 'Resume string returned by previous query.',
+                    'type': 'string'
+                },
+                'total': {
+                    'description': 'The number of devices',
+                    'type': 'integer'
+                }
+            },
+            'type': 'object'
+        }
+        self.assertEqual(isi_schema, expected)
+
 
 if __name__ == '__main__':
     if __package__ is None:

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -352,6 +352,44 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         }
         self.assertEqual(isi_schema, expected)
 
+    def test_nested_array_schema(self):
+        """Correct nested array schema."""
+        isi_schema = {
+            'properties': {
+                'causes': {
+                    'description': 'List of eventgroup IDs.',
+                    'items': {
+                        'type': {
+                            'description': 'Event Group cause.',
+                            'items': {'type': 'string'},
+                            'type': 'array'
+                        }
+                    },
+                    'type': 'array'
+                },
+            },
+            'type': 'object'
+        }
+        csc.isi_schema_to_swagger_object(
+            'EventEventgroupOccurrences', 'Eventgroup-Occurrence',
+            isi_schema, {}, 'Extended')
+
+        expected = {
+            'properties': {
+                'causes': {
+                    'description': 'List of eventgroup IDs.',
+                    'items': {
+                        'description': 'Event Group cause.',
+                        'items': {'type': 'string'},
+                        'type': 'array'
+                    },
+                    'type': 'array'
+                },
+            },
+            'type': 'object'
+        }
+        self.assertEqual(isi_schema, expected)
+
 
 if __name__ == '__main__':
     if __package__ is None:


### PR DESCRIPTION
Resolves issues #8, #9, #10, #11, #12, #13, #14, #15.

All but one of these fixes involve correcting invalid responses in the PAPI describe messages. The exception to that is issue #11, which required adding the POST item as a path parameter. This issue was impacting all of the Python packages while the others were only affecting a subset, since many of these schema issues were addressed in later OneFS releases.

I have included an additional unit test for each issue so that these workarounds will not regress in the future. 