### PR TITLE
Logging and technical debt reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository also includes tools to build PAPI bindings yourself for a large 
 
 | Cluster Version       | Install Instruction         |
 |-----------------------|-----------------------------|
+| OneFS 8.1.0 and later | `pip install isi_sdk_8_1_0` |
 | OneFS 8.0.1 and later | `pip install isi_sdk_8_0_1` |
 | OneFS 8.0 and later   | `pip install isi_sdk_8_0`   |
 | OneFS 7.2 and later   | `pip install isi_sdk_7_2`   |
@@ -34,11 +35,13 @@ Installation will default to using binary distribution wheel (bdist). Source dis
 
 See the generated packages on PyPI for example code:
 
-[isi\_sdk\_8\_0\_1](https://pypi.python.org/pypi/isi-sdk-8-0-1)
+[isi\_sdk\_8\_1\_0](https://pypi.org/pypi/isi-sdk-8-1-0)
 
-[isi\_sdk\_8\_0](https://pypi.python.org/pypi/isi-sdk-8-0)
+[isi\_sdk\_8\_0\_1](https://pypi.org/pypi/isi-sdk-8-0-1)
 
-[isi\_sdk\_7\_2](https://pypi.python.org/pypi/isi-sdk-7-2)
+[isi\_sdk\_8\_0](https://pypi.org/pypi/isi-sdk-8-0)
+
+[isi\_sdk\_7\_2](https://pypi.org/pypi/isi-sdk-7-2)
 
 ### Bindings Documentation
 
@@ -48,5 +51,3 @@ The most up-to-date documentation for the language bindings is included in the r
 
 * For OneFS API reference documents, discussions, and blog posts, refer to the [Isilon SDK Info Hub](https://community.emc.com/docs/DOC-48273).
 * To browse the Isilon InsightIQ statistics API, refer to the [Stat Key Browser](https://github.com/isilon/isilon_stat_browser.git) Github repository.
-
-

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -260,6 +260,8 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
 
     if isinstance(isi_schema['type'], list):
         for schema_list_item in isi_schema['type']:
+            if schema_list_item is None:
+                continue
             if 'type' not in schema_list_item:
                 # hack - just return empty object
                 return '#/definitions/Empty'
@@ -269,8 +271,7 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             # iterate until it has assigned the properties from the last
             # object in the list.
             if schema_list_item['type'] == 'object':
-                isi_schema['type'] = 'object'
-                isi_schema['properties'] = schema_list_item['properties']
+                isi_schema = schema_list_item
 
     if isi_schema['type'] != 'object':
         raise RuntimeError("isi_schema is not type 'object': {}".format(
@@ -1259,8 +1260,9 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/3/upgrade/cluster/patch/patches/<ID>', None),
-            (u'/3/upgrade/cluster/patch/patches', None),
+            ('/3/cluster/timezone', None),
+            ('/3/protocols/nfs/netgroup', None),
+            ('/3/upgrade/cluster/patch/abort', None),
         ]
 
     success_count = 0

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -69,11 +69,6 @@ def isi_props_to_swagger_params(isi_props, param_type):
                 log.warning('%s not defined for Swagger in prop: %s',
                             field_name, isi_prop)
                 continue
-            if field_name == 'pattern':
-                # XXX: bkrueger (27 Feb 2018) - Remove after upgrading
-                # Swagger from 2.2 to 2.3
-                # wrap with '/' to conform to Perl regex conventions
-                isi_prop['pattern'] = '/' + isi_prop['pattern'] + '/'
             if field_name == 'type':
                 if isi_prop[field_name] == 'int':
                     # HACK fix for bugs in the PAPI
@@ -225,8 +220,6 @@ def isi_to_swagger_array_prop(prop, prop_name, isi_obj_name,
             # Swagger does not support 'any'
             if prop['items']['type'] == 'any':
                 prop['items']['type'] = 'string'
-            if 'pattern' in prop['items']:
-                prop['items']['pattern'] = '/' + prop['items']['pattern'] + '/'
         elif prop['items']['type'] == 'int':
             log.warning('Invalid prop type in object %s prop %s: %s',
                         isi_obj_name, prop_name, prop)
@@ -540,9 +533,6 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             prop['type'] = 'integer'
             prop['minimum'] = 0
             prop['maximum'] = 10
-
-        if 'pattern' in prop:
-            prop['pattern'] = '/' + prop['pattern'] + '/'
 
     # attach required props
     if required_props:

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -66,8 +66,8 @@ def isi_props_to_swagger_params(isi_props, param_type):
         # attach common fields
         for field_name in isi_prop:
             if field_name not in SWAGGER_PARAM_ISI_PROP_COMMON_FIELDS:
-                log.warning('{} not defined for Swagger in prop: {}'.format(
-                    field_name, isi_prop))
+                log.warning('%s not defined for Swagger in prop: %s',
+                            field_name, isi_prop)
                 continue
             if field_name == 'pattern':
                 # XXX: bkrueger (27 Feb 2018) - Remove after upgrading
@@ -77,13 +77,13 @@ def isi_props_to_swagger_params(isi_props, param_type):
             if field_name == 'type':
                 if isi_prop[field_name] == 'int':
                     # HACK fix for bugs in the PAPI
-                    log.warning('Invalid type in params of type {}: {}'.
-                                format(param_type, isi_props))
+                    log.warning('Invalid type in params of type %s: %s',
+                                param_type, isi_props)
                     isi_prop[field_name] = 'integer'
                 elif isi_prop[field_name] == 'bool':
                     # HACK fix for bugs in the PAPI
-                    log.warning('Invalid type in params of type {}: {}'.
-                                format(param_type, isi_props))
+                    log.warning('Invalid type in params of type %s: %s',
+                                param_type, isi_props)
                     isi_prop[field_name] = 'boolean'
             swagger_param[field_name] = isi_prop[field_name]
         # add the new param to the list of params
@@ -217,13 +217,13 @@ def isi_to_swagger_array_prop(prop, prop_name, isi_obj_name,
             if 'pattern' in prop['items']:
                 prop['items']['pattern'] = '/' + prop['items']['pattern'] + '/'
         elif prop['items']['type'] == 'int':
-            log.warning('Invalid prop type in object {} prop {}: {}'.format(
-                isi_obj_name, prop_name, prop))
+            log.warning('Invalid prop type in object %s prop %s: %s',
+                        isi_obj_name, prop_name, prop)
             prop['items']['type'] = 'integer'
         elif prop['items']['type'] == 'bool':
             # HACK fix for bugs in the PAPI
-            log.warning('Invalid prop type in object {} prop {}: {}'.format(
-                isi_obj_name, prop_name, prop))
+            log.warning('Invalid prop type in object %s prop %s: %s',
+                        isi_obj_name, prop_name, prop)
             prop['items']['type'] = 'boolean'
 
     elif 'type' not in prop['items'] and '$ref' not in prop['items']:
@@ -241,16 +241,15 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
     if 'type' not in isi_schema:
         # have seen this for empty responses
         if 'properties' not in isi_schema and 'settings' not in isi_schema:
-            log.warning(('Invalid empty schema for object {}. '
-                         "Adding 'properties' and 'type'.").format(
-                             isi_obj_name))
+            log.warning(('Invalid empty schema for object %s. '
+                         "Adding 'properties' and 'type'."), isi_obj_name)
             schema_copy = isi_schema.copy()
             for key in isi_schema.keys():
                 del isi_schema[key]
             isi_schema['properties'] = schema_copy
         else:
-            log.warning(("Invalid schema for object {}, no 'type' specified. "
-                         "Adding 'type': 'object'.").format(isi_obj_name))
+            log.warning(("Invalid schema for object %s, no 'type' specified. "
+                         "Adding 'type': 'object'."), isi_obj_name)
         isi_schema['type'] = 'object'
 
     if isinstance(isi_schema['type'], list):
@@ -386,9 +385,8 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
 
         if 'type' not in prop:
             if 'enum' in prop:
-                log.warning(('Invalid enum prop with no type in object {} '
-                             'prop {}: {}').format(
-                                 isi_obj_name, prop_name, prop))
+                log.warning(('Invalid enum prop with no type in object %s '
+                             'prop %s: %s'), isi_obj_name, prop_name, prop)
                 prop['type'] = 'string'
             else:
                 continue  # must be a $ref
@@ -457,8 +455,8 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             for item in prop['enum']:
                 if not isinstance(item, str) and not isinstance(item, unicode):
                     log.warning(('Invalid prop with multi-type '
-                                 'enum in object {} prop {}: {}').format(
-                                     isi_obj_name, prop_name, prop))
+                                 'enum in object %s prop %s: %s'),
+                                isi_obj_name, prop_name, prop)
                     # Swagger can't deal with multi-type enums so just
                     # eliminate the enum.
                     new_enum = []
@@ -475,13 +473,13 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             prop['type'] = 'string'
         elif prop['type'] == 'int':
             # HACK fix for bugs in the PAPI
-            log.warning('Invalid prop type in object {} prop {}: {}'.format(
-                isi_obj_name, prop_name, prop))
+            log.warning('Invalid prop type in object %s prop %s: %s',
+                        isi_obj_name, prop_name, prop)
             prop['type'] = 'integer'
         elif prop['type'] == 'bool':
             # HACK fix for bugs in the PAPI
-            log.warning('Invalid prop type in object {} prop {}: {}'.format(
-                isi_obj_name, prop_name, prop))
+            log.warning('Invalid prop type in object %s prop %s: %s',
+                        isi_obj_name, prop_name, prop)
             prop['type'] = 'boolean'
 
         if 'pattern' in prop:
@@ -1261,9 +1259,8 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            (u'/3/cluster/config', None),
-            (u'/3/cluster/time', None),
-            (u'/3/cluster/version', None),
+            (u'/3/upgrade/cluster/patch/patches/<ID>', None),
+            (u'/3/upgrade/cluster/patch/patches', None),
         ]
 
     success_count = 0
@@ -1284,7 +1281,7 @@ def main():
             api_name, obj_namespace, obj_name, swagger_path)
 
         if item_end_point_path is not None:
-            log.info('Processing {}'.format(item_end_point_path))
+            log.info('Processing %s', item_end_point_path)
             # next do the item PUT (i.e. update), DELETE, and GET because the
             # GET seems to be a limited version of the base path GET so the
             # subclassing works correct when done in this order
@@ -1307,20 +1304,19 @@ def main():
                 swagger_json['paths'][swagger_path + item_path_url] = item_path
 
                 if 'HEAD_args' in item_resp_json:
-                    log.warning('HEAD_args in: {}'.format(
-                        item_end_point_path))
+                    log.warning('HEAD_args in: %s', item_end_point_path)
 
                 success_count += 1
             except (KeyError, TypeError, RuntimeError) as err:
-                log.error('Caught exception processing: {}'.format(
-                    item_end_point_path))
-                log.error('{}: {}'.format(type(err).__name__, err))
+                log.error('Caught exception processing: %s',
+                          item_end_point_path)
+                log.error('%s: %s', type(err).__name__, err)
                 if args.test:
                     traceback.print_exc(file=sys.stderr)
                 fail_count += 1
 
         if base_end_point_path is not None:
-            log.info('Processing {}'.format(base_end_point_path))
+            log.info('Processing %s', base_end_point_path)
             url = 'https://{}:{}{}{}'.format(
                 args.host, papi_port, base_url, base_end_point_path)
             resp = requests.get(
@@ -1358,13 +1354,12 @@ def main():
                     swagger_json['paths'][swagger_path] = base_path
 
                 if 'HEAD_args' in base_resp_json:
-                    log.warning('HEAD_args in: {}'.format(
-                        base_end_point_path))
+                    log.warning('HEAD_args in: %s', base_end_point_path)
                 success_count += 1
             except (KeyError, TypeError, RuntimeError) as err:
-                log.error('Caught exception processing: {}'.format(
-                    base_end_point_path))
-                log.error('{}: {}'.format(type(err).__name__, err))
+                log.error('Caught exception processing: %s',
+                          base_end_point_path)
+                log.error('%s: %s', type(err).__name__, err)
                 if args.test:
                     traceback.print_exc(file=sys.stderr)
                 fail_count += 1
@@ -1372,9 +1367,9 @@ def main():
     swagger_json['info']['version'] = onefs_short_version(
         args.host, papi_port, auth)
 
-    log.info(('End points successfully processed: {}, failed to process: {}, '
-              'excluded: {}.').format(
-                  success_count, fail_count, len(exclude_end_points)))
+    log.info(('End points successfully processed: %s, failed to process: %s, '
+              'excluded: %s.'),
+             success_count, fail_count, len(exclude_end_points))
 
     with open(args.output_file, 'w') as output_file:
         output_file.write(json.dumps(

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -159,6 +159,10 @@ def isi_to_swagger_array_prop(prop, prop_name, isi_obj_name,
             # XXX: bkrueger (8 Mar 2018) default to string if not defined
             prop['items'] = {'type': 'string'}
 
+    # protect against Java array out of bounds exception
+    if ('maxItems' in prop and prop['maxItems'] > 2147483642):
+        del prop['maxItems']
+
     if 'type' not in prop['items'] and prop['items'] == 'string':
         prop['items'] = {'type': 'string'}
     elif 'type' not in prop['items'] and prop['items'] == 'integer':
@@ -1266,6 +1270,8 @@ def main():
                         'description': ('ID of created item that can be used '
                                         'to refer to item in the collection-'
                                         'item resource path.'),
+                        'maxLength': 255,
+                        'minLength': 0,
                         'type': 'string'
                     }
                 },

--- a/excluded_end_points_7_2.json
+++ b/excluded_end_points_7_2.json
@@ -1,7 +1,10 @@
 [
 "/1/cluster/external-ips",
+"/1/debug/echo/<TOKEN>",
 "/1/event/events",
 "/1/event/events/<ID>",
+"/1/fsa/path",
+"/1/license/eula",
 "/1/protocols/nfs/aliases",
 "/1/protocols/nfs/aliases/<AID>",
 "/1/protocols/nfs/check",

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -448,6 +448,60 @@ class TestCreateSwaggerConfig(unittest.TestCase):
         }
         self.assertEqual(isi_schema, expected)
 
+    def test_singularize_status(self):
+        """FirmwareStatus to FirmwareStatusItem."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'FirmwareStatus', 'Item', used)
+
+        self.assertEqual(singular, 'FirmwareStatusItem')
+        self.assertTrue(used.flag)
+
+    def test_singularize_patches(self):
+        """PatchPatches to PatchPatch."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'PatchPatches', 'Item', used)
+
+        self.assertEqual(singular, 'PatchPatch')
+        self.assertFalse(used.flag)
+
+    def test_singularize_aliases(self):
+        """Aliases to Alias."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'Aliases', 'Item', used)
+
+        self.assertEqual(singular, 'Alias')
+        self.assertFalse(used.flag)
+
+    def test_singularize_phases(self):
+        """Phases to Phase."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'Phases', 'Item', used)
+
+        self.assertEqual(singular, 'Phase')
+        self.assertFalse(used.flag)
+
+    def test_singularize_licenses(self):
+        """Licenses to License."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'Licenses', 'Item', used)
+
+        self.assertEqual(singular, 'License')
+        self.assertFalse(used.flag)
+
+    def test_singularize_run_as_root(self):
+        """Run_As_Root to RunAsRootItem."""
+        used = csc.PostFixUsed()
+        singular = csc.plural_obj_name_to_singular(
+            'Run_As_Root', 'Item', used)
+
+        self.assertEqual(singular, 'RunAsRootItem')
+        self.assertTrue(used.flag)
+
 
 if __name__ == '__main__':
     if __package__ is None:

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -90,7 +90,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
 
         expected = [{
             'description': 'Licenses to include in activation file.',
-            'pattern': '/.+/',
+            'pattern': '.+',
             'in': 'query',
             'minLength': 1,
             'maxLength': 2500,


### PR DESCRIPTION
This PR accomplishes 4 things to reduce technical debt:

1. Replaces print statements with configurable logging levels
2. Corrects invalid conversion of object names from plural to singular
3. Excludes all non-JSON (e.g. plaintext and HTML) PAPI handlers
4. Resolves errors that were excluding some PAPI handlers from the SDK

In some cases, an additional 20+ PAPI handlers have been added to the Swagger config. The output below gives examples of how the number of successfully processed and excluded handlers changes as a result of this PR.

OneFS 7.2 previous output:
```
End points successfully processed: 209, failed to process: 4, excluded: 17.
```
After fixes:
```
04:10:13 INFO - End points successfully processed: 210, failed to process: 0, excluded: 20.
```
OneFS 8.0.0 previous output:
```
End points successfully processed: 356, failed to process: 26, excluded: 4.
```
After fixes:
```
04:10:58 INFO - End points successfully processed: 377, failed to process: 0, excluded: 11.
```
OneFS 8.0.1 previous output:
```
End points successfully processed: 391, failed to process: 27, excluded: 4.
```
After fixes:
```
04:13:47 INFO - End points successfully processed: 411, failed to process: 0, excluded: 11.
```
OneFS 8.1.0 previous output:
```
End points successfully processed: 398, failed to process: 27, excluded: 4.
```
After fixes:
```
04:16:31 INFO - End points successfully processed: 418, failed to process: 0, excluded: 11.
```
