### PR TITLE
Replace basic auth with session auth

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -1220,11 +1220,13 @@ def main():
             'application/json'
         ],
         'securityDefinitions': {
-            'basic_auth': {
-                'type': 'basic'
+            'sessionAuth': {
+                'type': 'apiKey',
+                'in': 'header',
+                'name': 'cookie'
             }
         },
-        'security': [{'basic_auth': []}],
+        'security': [{'sessionAuth': []}],
         'paths': {},
         'definitions': {}
     }

--- a/swagger_templates/python/api_client.diff
+++ b/swagger_templates/python/api_client.diff
@@ -1,14 +1,18 @@
-15c15
+11a12
+> import time
+15c16
 < from six.moves.urllib.parse import quote
 ---
 > from six.moves.urllib.parse import quote, quote_plus
-70a71,75
+70a72,78
 >         # This is used for detecting for the special case of a path parameter
 >         # that is tagged with x-isi-url-encode-path-param (more details in the
 >         # __call_api function).
 >         self.quote_plus_tag = "__x-isi-url-encode-path-param__"
 >         self.quote_plus_tag_len = len(self.quote_plus_tag)
-115a121,134
+>         self.session_expiration = 0
+>         self.x_csrf_token = None
+115a124,137
 >                 v_str = str(v)
 >                 # Check for the special case of the
 >                 # x-isi-url-encode-path-param, which indicates that the
@@ -23,13 +27,44 @@
 >                 else:
 >                     replacement = quote(v_str, safe=config.safe_chars_for_path_param)
 > 
-118,120c137
+118,120c140
 <                     '{%s}' % k,
 <                     quote(str(v), safe=config.safe_chars_for_path_param)
 <                 )
 ---
 >                     '{%s}' % k, replacement)
-412c429
+412c432
 <             if k in collection_formats:
 ---
 >             if k in collection_formats and not isinstance(v, self.PRIMITIVE_TYPES):
+514a535,564
+>         # check if PAPI session has expired
+>         if time.time() > self.session_expiration:
+>             url = self.configuration.host + '/session/1/session'
+>             body = {
+>                 'username': self.configuration.username,
+>                 'password': self.configuration.password,
+>                 'services': ['platform']
+>             }
+>             response_data = self.rest_client.POST(
+>                 url, headers=headers, body=body)
+> 
+>             if response_data.status == 201:
+>                 cookies = response_data.getheaders()['Set-Cookie']
+>                 self.cookie = cookies.split(';')[0]
+>                 timeout = json.loads(response_data.data)['timeout_inactive']
+>                 self.session_expiration = time.time() + timeout
+> 
+>                 try:
+>                     # extract X-CSRF token from response cookies
+>                     isicsrf = cookies[cookies.find('isicsrf'):]
+>                     self.x_csrf_token = isicsrf.split(';', 1)[0].split('=')[1]
+>                 except IndexError:
+>                     # this is not an anti-CSRF version of PAPI
+>                     pass
+> 
+>         headers['Cookie'] = self.cookie
+>         if self.x_csrf_token:
+>             headers['Origin'] = self.configuration.host
+>             headers['X-CSRF-Token'] = self.x_csrf_token
+> 

--- a/swagger_templates/python/api_client.diff
+++ b/swagger_templates/python/api_client.diff
@@ -4,15 +4,17 @@
 < from six.moves.urllib.parse import quote
 ---
 > from six.moves.urllib.parse import quote, quote_plus
-70a72,78
+70a72,80
 >         # This is used for detecting for the special case of a path parameter
 >         # that is tagged with x-isi-url-encode-path-param (more details in the
 >         # __call_api function).
 >         self.quote_plus_tag = "__x-isi-url-encode-path-param__"
 >         self.quote_plus_tag_len = len(self.quote_plus_tag)
+> 
 >         self.session_expiration = 0
+>         self.inactive_expiration = 0
 >         self.x_csrf_token = None
-115a124,137
+115a126,139
 >                 v_str = str(v)
 >                 # Check for the special case of the
 >                 # x-isi-url-encode-path-param, which indicates that the
@@ -27,19 +29,20 @@
 >                 else:
 >                     replacement = quote(v_str, safe=config.safe_chars_for_path_param)
 > 
-118,120c140
+118,120c142
 <                     '{%s}' % k,
 <                     quote(str(v), safe=config.safe_chars_for_path_param)
 <                 )
 ---
 >                     '{%s}' % k, replacement)
-412c432
+412c434
 <             if k in collection_formats:
 ---
 >             if k in collection_formats and not isinstance(v, self.PRIMITIVE_TYPES):
-514a535,564
+514a537,570
 >         # check if PAPI session has expired
->         if time.time() > self.session_expiration:
+>         now = time.time()
+>         if now >= self.session_expiration or now >= self.inactive_expiration:
 >             url = self.configuration.host + '/session/1/session'
 >             body = {
 >                 'username': self.configuration.username,
@@ -52,8 +55,8 @@
 >             if response_data.status == 201:
 >                 cookies = response_data.getheaders()['Set-Cookie']
 >                 self.cookie = cookies.split(';')[0]
->                 timeout = json.loads(response_data.data)['timeout_inactive']
->                 self.session_expiration = time.time() + timeout
+>                 timeout = json.loads(response_data.data)['timeout_absolute']
+>                 self.session_expiration = now + timeout
 > 
 >                 try:
 >                     # extract X-CSRF token from response cookies
@@ -62,6 +65,9 @@
 >                 except IndexError:
 >                     # this is not an anti-CSRF version of PAPI
 >                     pass
+> 
+>         # 15 seconds is the default keep alive timeout
+>         self.inactive_expiration = now + 15
 > 
 >         headers['Cookie'] = self.cookie
 >         if self.x_csrf_token:

--- a/swagger_templates/python/api_client.mustache
+++ b/swagger_templates/python/api_client.mustache
@@ -74,7 +74,9 @@ class ApiClient(object):
         # __call_api function).
         self.quote_plus_tag = "__x-isi-url-encode-path-param__"
         self.quote_plus_tag_len = len(self.quote_plus_tag)
+
         self.session_expiration = 0
+        self.inactive_expiration = 0
         self.x_csrf_token = None
 
     def __del__(self):
@@ -533,7 +535,8 @@ class ApiClient(object):
                     )
 
         # check if PAPI session has expired
-        if time.time() > self.session_expiration:
+        now = time.time()
+        if now >= self.session_expiration or now >= self.inactive_expiration:
             url = self.configuration.host + '/session/1/session'
             body = {
                 'username': self.configuration.username,
@@ -546,8 +549,8 @@ class ApiClient(object):
             if response_data.status == 201:
                 cookies = response_data.getheaders()['Set-Cookie']
                 self.cookie = cookies.split(';')[0]
-                timeout = json.loads(response_data.data)['timeout_inactive']
-                self.session_expiration = time.time() + timeout
+                timeout = json.loads(response_data.data)['timeout_absolute']
+                self.session_expiration = now + timeout
 
                 try:
                     # extract X-CSRF token from response cookies
@@ -556,6 +559,9 @@ class ApiClient(object):
                 except IndexError:
                     # this is not an anti-CSRF version of PAPI
                     pass
+
+        # 15 seconds is the default keep alive timeout
+        self.inactive_expiration = now + 15
 
         headers['Cookie'] = self.cookie
         if self.x_csrf_token:

--- a/swagger_templates/python/api_client.mustache
+++ b/swagger_templates/python/api_client.mustache
@@ -9,6 +9,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
+import time
 
 # python 2 and python 3 compatibility library
 import six
@@ -73,6 +74,8 @@ class ApiClient(object):
         # __call_api function).
         self.quote_plus_tag = "__x-isi-url-encode-path-param__"
         self.quote_plus_tag_len = len(self.quote_plus_tag)
+        self.session_expiration = 0
+        self.x_csrf_token = None
 
     def __del__(self):
         self.pool.close()
@@ -528,6 +531,36 @@ class ApiClient(object):
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'
                     )
+
+        # check if PAPI session has expired
+        if time.time() > self.session_expiration:
+            url = self.configuration.host + '/session/1/session'
+            body = {
+                'username': self.configuration.username,
+                'password': self.configuration.password,
+                'services': ['platform']
+            }
+            response_data = self.rest_client.POST(
+                url, headers=headers, body=body)
+
+            if response_data.status == 201:
+                cookies = response_data.getheaders()['Set-Cookie']
+                self.cookie = cookies.split(';')[0]
+                timeout = json.loads(response_data.data)['timeout_inactive']
+                self.session_expiration = time.time() + timeout
+
+                try:
+                    # extract X-CSRF token from response cookies
+                    isicsrf = cookies[cookies.find('isicsrf'):]
+                    self.x_csrf_token = isicsrf.split(';', 1)[0].split('=')[1]
+                except IndexError:
+                    # this is not an anti-CSRF version of PAPI
+                    pass
+
+        headers['Cookie'] = self.cookie
+        if self.x_csrf_token:
+            headers['Origin'] = self.configuration.host
+            headers['X-CSRF-Token'] = self.x_csrf_token
 
     def __deserialize_file(self, response):
         """Deserializes body to file


### PR DESCRIPTION
This PR replaces the Swagger basic auth implementation with a custom session auth flow using the `/session/1/session` endpoint on OneFS. This removes the requirement to re-authenticate for multiple requests that are in close succession. However, if the requests are spread farther than 15 seconds apart, then the KeepAliveTimeout in PAPI will disconnect on the server side. In this case, re-authentication is still required since the SDK could end up re-connecting to a different node in the cluster which does not recognize the node-specific session cookie. 

If the SDK's connection to the cluster remains active, then re-authentication will only be required every 4 hours by default. This is achieved by issuing a preliminary request to create the session, which will return back the session cookies in the `Set-Cookie` header. The cookies provided in that header will then be provided in the headers of all subsequent requests. Note that the `X-CSRF-Token` header will only be set if `isicsrf` exists in the `Set-Cookie` header.

This was tested with both frequent and infrequent requests to PAPI, as well as the edge cases around the 15 second KeepAliveTimeout. When the requests were greater than 15 seconds apart and the SDK `host` was configured to connect to a SmartConnect zone, then the SDK successfully re-connected and re-authenticated with each new node.