### PR TITLE
Update example test scripts and associated bugs

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -329,6 +329,12 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
                 isi_schema['properties']['interface']
             del isi_schema['properties']['interface']
             log.warning("Found 'interfaces' misspelled as 'interface'")
+    elif sub_obj_namespace == 'HardeningStatusStatus':
+        if 'status_text' in isi_schema['properties']:
+            isi_schema['properties']['message'] = \
+                isi_schema['properties']['status_text']
+            del isi_schema['properties']['status_text']
+            log.warning("Found 'message' labeled as 'status_text'")
 
     required_props = []
     for prop_name, prop in isi_schema['properties'].items():
@@ -456,6 +462,10 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if prop_name == 'settings' and 'items' in prop:
                 prop = prop['items']
                 log.warning("Property 'settings' is an object, not an array")
+        elif sub_obj_namespace == 'HardeningStateState':
+            if prop_name == 'state' and 'Other' not in prop['enum']:
+                prop['enum'].append('Other')
+                log.warning("Hardening state missing 'Other' in enum")
 
         if 'type' not in prop:
             if 'enum' in prop:

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -43,6 +43,9 @@ X_ISI_URL_ENCODE_PATH_PARAM = 'x-isi-url-encode-path-param'
 GENERATED_OPS = {}
 SWAGGER_DEFS = {}
 
+MAX_ARRAY_SIZE = 2147483642
+MAX_INTEGER_SIZE = 9223372036854775807
+
 
 def onefs_short_version(host, port, auth):
     """Query a cluster and return the 2 major version digits"""
@@ -154,7 +157,7 @@ def isi_to_swagger_array_prop(prop, prop_name, isi_obj_name,
             prop['items'] = {'type': 'string'}
 
     # protect against Java array out of bounds exception
-    if ('maxItems' in prop and prop['maxItems'] > 2147483642):
+    if ('maxItems' in prop and prop['maxItems'] > MAX_ARRAY_SIZE):
         del prop['maxItems']
 
     if 'type' not in prop['items'] and prop['items'] == 'string':
@@ -552,6 +555,9 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             prop['type'] = 'integer'
             prop['minimum'] = 0
             prop['maximum'] = 10
+        elif prop['type'] == 'integer':
+            if 'maximum' in prop and prop['maximum'] > MAX_INTEGER_SIZE:
+                prop['maximum'] = MAX_INTEGER_SIZE
 
     # attach required props
     if required_props:
@@ -1361,7 +1367,7 @@ def main():
     else:
         exclude_end_points = []
         end_point_paths = [
-            ('/2/cluster/external-ips', None)
+            ('/4/protocols/nfs/exports', None)
         ]
 
     success_count = 0

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -335,6 +335,12 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
                 isi_schema['properties']['status_text']
             del isi_schema['properties']['status_text']
             log.warning("Found 'message' labeled as 'status_text'")
+    elif sub_obj_namespace == 'NdmpLogsNode':
+        if 'logs:' in isi_schema['properties']:
+            isi_schema['properties']['logs'] = \
+                isi_schema['properties']['logs:']
+            del isi_schema['properties']['logs:']
+            log.warning("Found 'logs' misspelled as 'logs:'")
 
     required_props = []
     for prop_name, prop in isi_schema['properties'].items():

--- a/tests/test_antivirus_policies.py
+++ b/tests/test_antivirus_policies.py
@@ -1,66 +1,70 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
 
 # configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-antivirusApi = isi_sdk.AntivirusApi(apiClient)
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+antivirus_api = isi_sdk.AntivirusApi(api_client)
 
 # create a new policy
-newPolicy = isi_sdk.AntivirusPolicy()
-newPolicy.paths = ["/ifs/data"]
-newPolicy.name = "ifs_data"
+new_policy = isi_sdk.AntivirusPolicy()
+new_policy.paths = ["/ifs/data/Isilon_Support"]
+new_policy.name = "ifs_data_support"
 
 # use force because path already exists as policy so would normally fail
-createResp = antivirusApi.create_antivirus_policy(newPolicy)
-print "Created=" + str(createResp.id)
+create_resp = antivirus_api.create_antivirus_policy(new_policy)
+print("Created=" + str(create_resp.id))
 
 # get it by id
-getPolicyResp = antivirusApi.get_antivirus_policy(createResp.id)
+get_policy_resp = antivirus_api.get_antivirus_policy(create_resp.id)
 
 # update it with a PUT
-aPolicy = getPolicyResp.policies[0]
+policy = get_policy_resp.policies[0]
 
-updatePolicy = isi_sdk.AntivirusPolicy()
+update_policy = isi_sdk.AntivirusPolicy()
 
 # toggle the browsable parameter
-updatePolicy.enabled = aPolicy.enabled == False
+update_policy.enabled = policy.enabled == False
 
-antivirusApi.update_antivirus_policy(antivirus_policy_id=aPolicy.id,
-                                     antivirus_policy=updatePolicy)
+antivirus_api.update_antivirus_policy(antivirus_policy_id=policy.id,
+                                      antivirus_policy=update_policy)
 
 
 # get it back and check that it worked
-getPolicyResp = antivirusApi.get_antivirus_policy(aPolicy.id)
+get_policy_resp = antivirus_api.get_antivirus_policy(policy.id)
 
-print "It worked == " \
-        + str(getPolicyResp.policies[0].enabled == updatePolicy.enabled)
+print("It worked == " +
+      str(get_policy_resp.policies[0].enabled == update_policy.enabled))
 
 # get all policies
-antivirusPolicies = antivirusApi.list_antivirus_policies()
-print "Antivirus Policies:\n" + str(antivirusPolicies)
+antivirus_policies = antivirus_api.list_antivirus_policies()
+print("Antivirus Policies:\n" + str(antivirus_policies))
 
 # now delete it
-print "Deleting it."
-antivirusApi.delete_antivirus_policy(antivirus_policy_id=createResp.id)
+print("Deleting it.")
+antivirus_api.delete_antivirus_policy(antivirus_policy_id=create_resp.id)
 
 # verify that it is deleted
 # Note: my Error data model is not correct yet,
-# so get on a non-existent antivirus policy id throws exception. Ideally it would
-# just return an error response
+# so get on a non-existent antivirus policy id throws exception.
+# Ideally it would just return an error response
 try:
-    print "Verifying delete."
-    resp = antivirusApi.get_antivirus_policy(antivirus_policy_id=createResp.id)
-    print "Response should be 404, not: " + str(resp)
+    print("Verifying delete.")
+    resp = antivirus_api.get_antivirus_policy(
+        antivirus_policy_id=create_resp.id)
+    print("Response should be 404, not: " + str(resp))
 except isi_sdk.rest.ApiException:
     pass
 
-print "Done."
+print("Done.")

--- a/tests/test_antivirus_policies.py
+++ b/tests/test_antivirus_policies.py
@@ -6,65 +6,71 @@ import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-antivirus_api = isi_sdk.AntivirusApi(api_client)
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# create a new policy
-new_policy = isi_sdk.AntivirusPolicy()
-new_policy.paths = ["/ifs/data/Isilon_Support"]
-new_policy.name = "ifs_data_support"
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    antivirus_api = isi_sdk.AntivirusApi(api_client)
 
-# use force because path already exists as policy so would normally fail
-create_resp = antivirus_api.create_antivirus_policy(new_policy)
-print("Created=" + str(create_resp.id))
+    # create a new policy
+    new_policy = isi_sdk.AntivirusPolicy()
+    new_policy.paths = ["/ifs/data/Isilon_Support"]
+    new_policy.name = "ifs_data_support"
 
-# get it by id
-get_policy_resp = antivirus_api.get_antivirus_policy(create_resp.id)
+    # use force because path already exists as policy so would normally fail
+    create_resp = antivirus_api.create_antivirus_policy(new_policy)
+    print("Created=" + str(create_resp.id))
 
-# update it with a PUT
-policy = get_policy_resp.policies[0]
+    # get it by id
+    get_policy_resp = antivirus_api.get_antivirus_policy(create_resp.id)
 
-update_policy = isi_sdk.AntivirusPolicy()
+    # update it with a PUT
+    policy = get_policy_resp.policies[0]
 
-# toggle the browsable parameter
-update_policy.enabled = policy.enabled == False
+    update_policy = isi_sdk.AntivirusPolicy()
 
-antivirus_api.update_antivirus_policy(antivirus_policy_id=policy.id,
-                                      antivirus_policy=update_policy)
+    # toggle the browsable parameter
+    update_policy.enabled = not policy.enabled
+
+    antivirus_api.update_antivirus_policy(antivirus_policy_id=policy.id,
+                                          antivirus_policy=update_policy)
 
 
-# get it back and check that it worked
-get_policy_resp = antivirus_api.get_antivirus_policy(policy.id)
+    # get it back and check that it worked
+    get_policy_resp = antivirus_api.get_antivirus_policy(policy.id)
 
-print("It worked == " +
-      str(get_policy_resp.policies[0].enabled == update_policy.enabled))
+    print("It worked == " +
+          str(get_policy_resp.policies[0].enabled == update_policy.enabled))
 
-# get all policies
-antivirus_policies = antivirus_api.list_antivirus_policies()
-print("Antivirus Policies:\n" + str(antivirus_policies))
+    # get all policies
+    antivirus_policies = antivirus_api.list_antivirus_policies()
+    print("Antivirus Policies:\n" + str(antivirus_policies))
 
-# now delete it
-print("Deleting it.")
-antivirus_api.delete_antivirus_policy(antivirus_policy_id=create_resp.id)
+    # now delete it
+    print("Deleting it.")
+    antivirus_api.delete_antivirus_policy(antivirus_policy_id=create_resp.id)
 
-# verify that it is deleted
-# Note: my Error data model is not correct yet,
-# so get on a non-existent antivirus policy id throws exception.
-# Ideally it would just return an error response
-try:
-    print("Verifying delete.")
-    resp = antivirus_api.get_antivirus_policy(
-        antivirus_policy_id=create_resp.id)
-    print("Response should be 404, not: " + str(resp))
-except isi_sdk.rest.ApiException:
-    pass
+    # verify that it is deleted
+    # Note: my Error data model is not correct yet,
+    # so get on a non-existent antivirus policy id throws exception.
+    # Ideally it would just return an error response
+    try:
+        print("Verifying delete.")
+        resp = antivirus_api.get_antivirus_policy(
+            antivirus_policy_id=create_resp.id)
+        print("Response should be 404, not: " + str(resp))
+    except isi_sdk.rest.ApiException:
+        pass
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_antivirus_quarantine.py
+++ b/tests/test_antivirus_quarantine.py
@@ -6,44 +6,50 @@ import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-antivirus_api = isi_sdk.AntivirusApi(api_client)
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# update quarantine path
-update_quarantine_path_params = isi_sdk.AntivirusQuarantinePathParams()
-update_quarantine_path_params.quarantined = True
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    antivirus_api = isi_sdk.AntivirusApi(api_client)
 
-quarantine_path = "ifs/README.txt"
-antivirus_api.update_antivirus_quarantine_path(
-    antivirus_quarantine_path=quarantine_path,
-    antivirus_quarantine_path_params=update_quarantine_path_params)
+    # update quarantine path
+    update_quarantine_path_params = isi_sdk.AntivirusQuarantinePathParams()
+    update_quarantine_path_params.quarantined = True
 
-# get it back and check that it worked
-get_quarantine_path_resp = \
-    antivirus_api.get_antivirus_quarantine_path(quarantine_path)
-print("It worked == " +
-      str(get_quarantine_path_resp.quarantined ==
-          update_quarantine_path_params.quarantined))
+    quarantine_path = "ifs/README.txt"
+    antivirus_api.update_antivirus_quarantine_path(
+        antivirus_quarantine_path=quarantine_path,
+        antivirus_quarantine_path_params=update_quarantine_path_params)
 
-# now unquarantine it
-update_quarantine_path_params.quarantined = False
-antivirus_api.update_antivirus_quarantine_path(
-    antivirus_quarantine_path=quarantine_path,
-    antivirus_quarantine_path_params=update_quarantine_path_params)
+    # get it back and check that it worked
+    get_quarantine_path_resp = \
+        antivirus_api.get_antivirus_quarantine_path(quarantine_path)
+    print("It worked == " +
+          str(get_quarantine_path_resp.quarantined ==
+              update_quarantine_path_params.quarantined))
 
-# verify it is no longer quarantined
-get_quarantine_path_resp = \
-    antivirus_api.get_antivirus_quarantine_path(quarantine_path)
-print("It worked == " +
-      str(get_quarantine_path_resp.quarantined ==
-          update_quarantine_path_params.quarantined))
+    # now unquarantine it
+    update_quarantine_path_params.quarantined = False
+    antivirus_api.update_antivirus_quarantine_path(
+        antivirus_quarantine_path=quarantine_path,
+        antivirus_quarantine_path_params=update_quarantine_path_params)
 
-print("Done.")
+    # verify it is no longer quarantined
+    get_quarantine_path_resp = \
+        antivirus_api.get_antivirus_quarantine_path(quarantine_path)
+    print("It worked == " +
+          str(get_quarantine_path_resp.quarantined ==
+              update_quarantine_path_params.quarantined))
+
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_antivirus_quarantine.py
+++ b/tests/test_antivirus_quarantine.py
@@ -1,46 +1,49 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-antivirusApi = isi_sdk.AntivirusApi(apiClient)
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+antivirus_api = isi_sdk.AntivirusApi(api_client)
 
 # update quarantine path
-updateQuarantinePathParams = isi_sdk.AntivirusQuarantinePathParams()
-updateQuarantinePathParams.quarantined = True
+update_quarantine_path_params = isi_sdk.AntivirusQuarantinePathParams()
+update_quarantine_path_params.quarantined = True
 
-quarantinePath = "/ifs/README.txt"
-antivirusApi.update_antivirus_quarantine_path(
-        antivirus_quarantine_path=quarantinePath,
-        antivirus_quarantine_path_params=updateQuarantinePathParams)
-
+quarantine_path = "ifs/README.txt"
+antivirus_api.update_antivirus_quarantine_path(
+    antivirus_quarantine_path=quarantine_path,
+    antivirus_quarantine_path_params=update_quarantine_path_params)
 
 # get it back and check that it worked
-getQuarantinePathResp = \
-        antivirusApi.get_antivirus_quarantine_path(quarantinePath)
-print "It worked == " \
-        + str(getQuarantinePathResp.quarantined
-                == updateQuarantinePathParams.quarantined)
+get_quarantine_path_resp = \
+    antivirus_api.get_antivirus_quarantine_path(quarantine_path)
+print("It worked == " +
+      str(get_quarantine_path_resp.quarantined ==
+          update_quarantine_path_params.quarantined))
 
 # now unquarantine it
-updateQuarantinePathParams.quarantined = False
-antivirusApi.update_antivirus_quarantine_path(
-        antivirus_quarantine_path=quarantinePath,
-        antivirus_quarantine_path_params=updateQuarantinePathParams)
+update_quarantine_path_params.quarantined = False
+antivirus_api.update_antivirus_quarantine_path(
+    antivirus_quarantine_path=quarantine_path,
+    antivirus_quarantine_path_params=update_quarantine_path_params)
 
 # verify it is no longer quarantined
-getQuarantinePathResp = \
-        antivirusApi.get_antivirus_quarantine_path(quarantinePath)
-print "It worked == " \
-        + str(getQuarantinePathResp.quarantined
-                == updateQuarantinePathParams.quarantined)
+get_quarantine_path_resp = \
+    antivirus_api.get_antivirus_quarantine_path(quarantine_path)
+print("It worked == " +
+      str(get_quarantine_path_resp.quarantined ==
+          update_quarantine_path_params.quarantined))
 
-print "Done."
+print("Done.")

--- a/tests/test_antivirus_scan.py
+++ b/tests/test_antivirus_scan.py
@@ -1,21 +1,25 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-antivirusApi = isi_sdk.AntivirusApi(apiClient)
+
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+antivirus_api = isi_sdk.AntivirusApi(api_client)
 
 # create scan item
-newScanItem = isi_sdk.AntivirusScanItem()
-newScanItem.file = "/ifs/README.txt"
+new_scan_item = isi_sdk.AntivirusScanItem(file="/ifs/README.txt")
 
 # You'll have to specify an antivirus icap server before this will work.
 # POST the following body to /platform/3/antivirus/servers to enable it.
@@ -24,10 +28,9 @@ newScanItem.file = "/ifs/README.txt"
 #     "enabled": True
 # }
 
-scanResult = \
-        antivirusApi.create_antivirus_scan_item(
-                antivirus_scan_item=newScanItem)
+scan_result = \
+    antivirus_api.create_antivirus_scan_item(
+        antivirus_scan_item=new_scan_item)
 
-print "Scan result == " + str(scanResult)
-
-print "Done."
+print("Scan result == " + str(scan_result))
+print("Done.")

--- a/tests/test_antivirus_scan.py
+++ b/tests/test_antivirus_scan.py
@@ -7,30 +7,35 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-antivirus_api = isi_sdk.AntivirusApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    antivirus_api = isi_sdk.AntivirusApi(api_client)
 
-# create scan item
-new_scan_item = isi_sdk.AntivirusScanItem(file="/ifs/README.txt")
+    # create scan item
+    new_scan_item = isi_sdk.AntivirusScanItem(file="/ifs/README.txt")
 
-# You'll have to specify an antivirus icap server before this will work.
-# POST the following body to /platform/3/antivirus/servers to enable it.
-# {
-#     "url": "icap://YOUR_ICAP_SERVER_ADDRESS",
-#     "enabled": True
-# }
+    # You'll have to specify an antivirus icap server before this will work.
+    # POST the following body to /platform/3/antivirus/servers to enable it.
+    # {
+    #     "url": "icap://YOUR_ICAP_SERVER_ADDRESS",
+    #     "enabled": True
+    # }
 
-scan_result = \
-    antivirus_api.create_antivirus_scan_item(
-        antivirus_scan_item=new_scan_item)
+    scan_result = \
+        antivirus_api.create_antivirus_scan_item(
+            antivirus_scan_item=new_scan_item)
 
-print("Scan result == " + str(scan_result))
-print("Done.")
+    print("Scan result == " + str(scan_result))
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_antivirus_settings.py
+++ b/tests/test_antivirus_settings.py
@@ -1,28 +1,33 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
+
+
 # configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-antivirusApi = isi_sdk.AntivirusApi(apiClient)
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+antivirus_api = isi_sdk.AntivirusApi(api_client)
 
-settings = antivirusApi.get_antivirus_settings()
-print "Settings=" + str(settings)
+settings = antivirus_api.get_antivirus_settings()
+print("Settings=" + str(settings))
 
 settings.settings.repair = not settings.settings.repair
-antivirusApi.update_antivirus_settings(settings.settings)
+antivirus_api.update_antivirus_settings(settings.settings)
 
 # verify it worked
-updated = antivirusApi.get_antivirus_settings()
+updated = antivirus_api.get_antivirus_settings()
 
-print "It worked: " + str(settings.settings.repair
-                            == updated.settings.repair)
+print("It worked: " +
+      str(settings.settings.repair == updated.settings.repair))
 
-print "Done."
+print("Done.")

--- a/tests/test_antivirus_settings.py
+++ b/tests/test_antivirus_settings.py
@@ -7,27 +7,32 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-antivirus_api = isi_sdk.AntivirusApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    antivirus_api = isi_sdk.AntivirusApi(api_client)
 
-settings = antivirus_api.get_antivirus_settings()
-print("Settings=" + str(settings))
+    settings = antivirus_api.get_antivirus_settings()
+    print("Settings=" + str(settings))
 
-settings.settings.repair = not settings.settings.repair
-antivirus_api.update_antivirus_settings(settings.settings)
+    settings.settings.repair = not settings.settings.repair
+    antivirus_api.update_antivirus_settings(settings.settings)
 
-# verify it worked
-updated = antivirus_api.get_antivirus_settings()
+    # verify it worked
+    updated = antivirus_api.get_antivirus_settings()
 
-print("It worked: " +
-      str(settings.settings.repair == updated.settings.repair))
+    print("It worked: " +
+          str(settings.settings.repair == updated.settings.repair))
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_auth_access.py
+++ b/tests/test_auth_access.py
@@ -7,23 +7,28 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-auth_api = isi_sdk.AuthApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    auth_api = isi_sdk.AuthApi(api_client)
 
-accessUser = "root"
-path = "/ifs/data"
+    accessUser = "root"
+    path = "/ifs/data"
 
-get_access_user_resp = auth_api.get_auth_access_user(
-    auth_access_user=accessUser, path=path)
+    get_access_user_resp = auth_api.get_auth_access_user(
+        auth_access_user=accessUser, path=path)
 
-print("It worked: " + str(get_access_user_resp.access[0].id == accessUser))
+    print("It worked: " + str(get_access_user_resp.access[0].id == accessUser))
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_auth_access.py
+++ b/tests/test_auth_access.py
@@ -1,24 +1,29 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-authApi = isi_sdk.AuthApi(apiClient)
+
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+auth_api = isi_sdk.AuthApi(api_client)
 
 accessUser = "root"
 path = "/ifs/data"
 
-getAccessUserResp = \
-        authApi.get_auth_access_user(auth_access_user=accessUser, path=path)
+get_access_user_resp = auth_api.get_auth_access_user(
+    auth_access_user=accessUser, path=path)
 
-print "It worked: " + str(getAccessUserResp.access[0].id == accessUser)
+print("It worked: " + str(get_access_user_resp.access[0].id == accessUser))
 
-print "Done."
+print("Done.")

--- a/tests/test_auth_groups.py
+++ b/tests/test_auth_groups.py
@@ -1,88 +1,106 @@
-import isi_sdk
+import json
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+from isi_sdk_8_0.rest import ApiException
+
 import test_constants
 
 urllib3.disable_warnings()
+
+
 # configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-authApi = isi_sdk.AuthApi(apiClient)
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+auth_api = isi_sdk.AuthApi(api_client)
 
-newAuthGroup = isi_sdk.AuthGroupCreateParams()
-newAuthGroup.name = "alex"
+new_auth_group = isi_sdk.AuthGroupCreateParams(name='admins')
 
-print "Creating group " + newAuthGroup.name
-createAuthGroupResp = authApi.create_auth_group(newAuthGroup)
+print("Creating group %s" % new_auth_group.name)
+try:
+    create_auth_group_resp = auth_api.create_auth_group(new_auth_group)
+    print("Created: %s" % create_auth_group_resp.id)
+except ApiException as err:
+    if err.status == 409:
+        print("Group %s already exists" % new_auth_group.name)
+    else:
+        raise err
 
-print "Created: " + str(createAuthGroupResp)
+auth_groups = auth_api.list_auth_groups()
 
-authGroups = authApi.list_auth_groups()
+found_new_group = False
+for group in auth_groups.groups:
+    if group.name == new_auth_group.name:
+        found_new_group = True
 
-foundNewGroup = False
-for group in authGroups.groups:
-    if group.name == newAuthGroup.name:
-        foundNewGroup = True
+print("Found it: " + str(found_new_group))
 
-print "Found it: " + str(foundNewGroup)
+auth_groups = auth_api.get_auth_group(auth_group_id=new_auth_group.name)
 
-authGroups = authApi.get_auth_group(auth_group_id=newAuthGroup.name)
+found_new_group = False
+for group in auth_groups.groups:
+    if group.name == new_auth_group.name:
+        found_new_group = True
 
-foundNewGroup = False
-for group in authGroups.groups:
-    if group.name == newAuthGroup.name:
-        foundNewGroup = True
+print("Found it again: " + str(found_new_group))
 
-print "Found it again: " + str(foundNewGroup)
-
-updateAuthGroup = isi_sdk.AuthGroup()
+auth_group = isi_sdk.AuthGroup()
 # The only updatable value according to the description is the gid, but when i
-# try to change it, the response is that i need to include a force parameter,
+# try to change it, the response is that I need to include a force parameter,
 # but there is no force parameter in the description. Seems like a bug.
-authApi.update_auth_group(auth_group_id=newAuthGroup.name,
-                          auth_group=updateAuthGroup)
+auth_api.update_auth_group(auth_group_id=new_auth_group.name,
+                           auth_group=auth_group)
 
 # try adding a member
-groupMember = isi_sdk.GroupMember()
-groupMember.name = "admin"
-groupMember.type = "user"
+group_member = isi_sdk.GroupMember(name='admin', type='user')
 
-authGroupsApi = isi_sdk.AuthGroupsApi(apiClient)
-authGroupsApi.create_group_member(group=newAuthGroup.name,
-        group_member=groupMember)
+auth_groups_api = isi_sdk.AuthGroupsApi(api_client)
+try:
+    auth_groups_api.create_group_member(
+        group=new_auth_group.name, group_member=group_member)
+except ApiException as err:
+    body = json.loads(err.body)
+    if 'User is already in local group' in body['errors'][0]['message']:
+        print('User %s is already in local group' % group_member.name)
+    else:
+        raise err
+except ValueError as err:
+    print('Resource ID was not returned in response')
 
-groupMembers = authGroupsApi.list_group_members(group=newAuthGroup.name)
-foundMember = False
-for member in groupMembers.members:
-    if member.name == groupMember.name:
-        foundMember = True
+group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
+found_member = False
+for member in group_members.members:
+    if member.name == group_member.name:
+        found_member = True
 
-print "Found member: " + str(foundMember)
+print("Found member: " + str(found_member))
 
 # delete the member
-authGroupsApi.delete_group_member(group=newAuthGroup.name,
-        group_member_id=groupMembers.members[0].id)
+auth_groups_api.delete_group_member(
+    group=new_auth_group.name, group_member_id=group_members.members[0].id)
 
-groupMembers = authGroupsApi.list_group_members(group=newAuthGroup.name)
-foundMember = False
-for member in groupMembers.members:
-    if member.name == groupMember.name:
-        foundMember = True
+group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
+found_member = False
+for member in group_members.members:
+    if member.name == group_member.name:
+        found_member = True
 
-print "Deleted member: " + str(foundMember == False)
+print("Deleted member: " + str(found_member == False))
 
-authApi.delete_auth_group(newAuthGroup.name)
+auth_api.delete_auth_group(new_auth_group.name)
 
-authGroups = authApi.list_auth_groups()
-foundNewGroup = False
-for group in authGroups.groups:
-    if group.name == newAuthGroup.name:
-        foundNewGroup = True
+auth_groups = auth_api.list_auth_groups()
+found_new_group = False
+for group in auth_groups.groups:
+    if group.name == new_auth_group.name:
+        found_new_group = True
 
-print "Deleted it: " + str(foundNewGroup == False)
+print("Deleted it: " + str(found_new_group == False))
 
-print "Done."
+print("Done.")

--- a/tests/test_auth_groups.py
+++ b/tests/test_auth_groups.py
@@ -2,7 +2,6 @@ import json
 import urllib3
 
 import isi_sdk_8_0 as isi_sdk
-from isi_sdk_8_0.rest import ApiException
 
 import test_constants
 
@@ -26,7 +25,7 @@ print("Creating group %s" % new_auth_group.name)
 try:
     create_auth_group_resp = auth_api.create_auth_group(new_auth_group)
     print("Created: %s" % create_auth_group_resp.id)
-except ApiException as err:
+except isi_sdk.rest.ApiException as err:
     if err.status == 409:
         print("Group %s already exists" % new_auth_group.name)
     else:
@@ -64,7 +63,7 @@ auth_groups_api = isi_sdk.AuthGroupsApi(api_client)
 try:
     auth_groups_api.create_group_member(
         group=new_auth_group.name, group_member=group_member)
-except ApiException as err:
+except isi_sdk.rest.ApiException as err:
     body = json.loads(err.body)
     if 'User is already in local group' in body['errors'][0]['message']:
         print('User %s is already in local group' % group_member.name)

--- a/tests/test_auth_groups.py
+++ b/tests/test_auth_groups.py
@@ -8,98 +8,103 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-auth_api = isi_sdk.AuthApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    auth_api = isi_sdk.AuthApi(api_client)
 
-new_auth_group = isi_sdk.AuthGroupCreateParams(name='admins')
+    new_auth_group = isi_sdk.AuthGroupCreateParams(name='admins')
 
-print("Creating group %s" % new_auth_group.name)
-try:
-    create_auth_group_resp = auth_api.create_auth_group(new_auth_group)
-    print("Created: %s" % create_auth_group_resp.id)
-except isi_sdk.rest.ApiException as err:
-    if err.status == 409:
-        print("Group %s already exists" % new_auth_group.name)
-    else:
-        raise err
+    print("Creating group %s" % new_auth_group.name)
+    try:
+        create_auth_group_resp = auth_api.create_auth_group(new_auth_group)
+        print("Created: %s" % create_auth_group_resp.id)
+    except isi_sdk.rest.ApiException as err:
+        if err.status == 409:
+            print("Group %s already exists" % new_auth_group.name)
+        else:
+            raise err
 
-auth_groups = auth_api.list_auth_groups()
+    auth_groups = auth_api.list_auth_groups()
 
-found_new_group = False
-for group in auth_groups.groups:
-    if group.name == new_auth_group.name:
-        found_new_group = True
+    found_new_group = False
+    for group in auth_groups.groups:
+        if group.name == new_auth_group.name:
+            found_new_group = True
 
-print("Found it: " + str(found_new_group))
+    print("Found it: " + str(found_new_group))
 
-auth_groups = auth_api.get_auth_group(auth_group_id=new_auth_group.name)
+    auth_groups = auth_api.get_auth_group(auth_group_id=new_auth_group.name)
 
-found_new_group = False
-for group in auth_groups.groups:
-    if group.name == new_auth_group.name:
-        found_new_group = True
+    found_new_group = False
+    for group in auth_groups.groups:
+        if group.name == new_auth_group.name:
+            found_new_group = True
 
-print("Found it again: " + str(found_new_group))
+    print("Found it again: " + str(found_new_group))
 
-auth_group = isi_sdk.AuthGroup()
-# The only updatable value according to the description is the gid, but when i
-# try to change it, the response is that I need to include a force parameter,
-# but there is no force parameter in the description. Seems like a bug.
-auth_api.update_auth_group(auth_group_id=new_auth_group.name,
-                           auth_group=auth_group)
+    auth_group = isi_sdk.AuthGroup()
+    # The only updatable value according to the description is the gid, but when i
+    # try to change it, the response is that I need to include a force parameter,
+    # but there is no force parameter in the description. Seems like a bug.
+    auth_api.update_auth_group(auth_group_id=new_auth_group.name,
+                               auth_group=auth_group)
 
-# try adding a member
-group_member = isi_sdk.GroupMember(name='admin', type='user')
+    # try adding a member
+    group_member = isi_sdk.GroupMember(name='admin', type='user')
 
-auth_groups_api = isi_sdk.AuthGroupsApi(api_client)
-try:
-    auth_groups_api.create_group_member(
-        group=new_auth_group.name, group_member=group_member)
-except isi_sdk.rest.ApiException as err:
-    body = json.loads(err.body)
-    if 'User is already in local group' in body['errors'][0]['message']:
-        print('User %s is already in local group' % group_member.name)
-    else:
-        raise err
-except ValueError as err:
-    print('Resource ID was not returned in response')
+    auth_groups_api = isi_sdk.AuthGroupsApi(api_client)
+    try:
+        auth_groups_api.create_group_member(
+            group=new_auth_group.name, group_member=group_member)
+    except isi_sdk.rest.ApiException as err:
+        body = json.loads(err.body)
+        if 'User is already in local group' in body['errors'][0]['message']:
+            print('User %s is already in local group' % group_member.name)
+        else:
+            raise err
+    except ValueError as err:
+        print('Resource ID was not returned in response')
 
-group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
-found_member = False
-for member in group_members.members:
-    if member.name == group_member.name:
-        found_member = True
+    group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
+    found_member = False
+    for member in group_members.members:
+        if member.name == group_member.name:
+            found_member = True
 
-print("Found member: " + str(found_member))
+    print("Found member: " + str(found_member))
 
-# delete the member
-auth_groups_api.delete_group_member(
-    group=new_auth_group.name, group_member_id=group_members.members[0].id)
+    # delete the member
+    auth_groups_api.delete_group_member(
+        group=new_auth_group.name, group_member_id=group_members.members[0].id)
 
-group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
-found_member = False
-for member in group_members.members:
-    if member.name == group_member.name:
-        found_member = True
+    group_members = auth_groups_api.list_group_members(group=new_auth_group.name)
+    found_member = False
+    for member in group_members.members:
+        if member.name == group_member.name:
+            found_member = True
 
-print("Deleted member: " + str(found_member == False))
+    print("Deleted member: " + str(found_member == False))
 
-auth_api.delete_auth_group(new_auth_group.name)
+    auth_api.delete_auth_group(new_auth_group.name)
 
-auth_groups = auth_api.list_auth_groups()
-found_new_group = False
-for group in auth_groups.groups:
-    if group.name == new_auth_group.name:
-        found_new_group = True
+    auth_groups = auth_api.list_auth_groups()
+    found_new_group = False
+    for group in auth_groups.groups:
+        if group.name == new_auth_group.name:
+            found_new_group = True
 
-print("Deleted it: " + str(found_new_group == False))
+    print("Deleted it: " + str(found_new_group == False))
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,26 +1,30 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-clusterApi = isi_sdk.ClusterApi(apiClient)
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+clusterApi = isi_sdk.ClusterApi(api_client)
 
 # these two end points were throwing exceptions before so just testing that
 # they have any response at all for now.
-print str(clusterApi.get_cluster_config())
-print "It worked."
+print(str(clusterApi.get_cluster_config()))
+print("It worked.")
 
-print str(clusterApi.get_cluster_version())
-print "It worked."
+print(str(clusterApi.get_cluster_version()))
+print("It worked.")
 
-print str(clusterApi.get_cluster_external_ips())
-print "Done."
+print(str(clusterApi.get_cluster_external_ips()))
+print("Done.")

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -7,24 +7,29 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-cluster_api = isi_sdk.ClusterApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    cluster_api = isi_sdk.ClusterApi(api_client)
 
-# these two end points were throwing exceptions before so just testing that
-# they have any response at all for now.
-print(str(cluster_api.get_cluster_config()))
-print("It worked.")
+    # these two end points were throwing exceptions before so just testing that
+    # they have any response at all for now.
+    print(str(cluster_api.get_cluster_config()))
+    print("It worked.")
 
-print(str(cluster_api.get_cluster_version()))
-print("It worked.")
+    print(str(cluster_api.get_cluster_version()))
+    print("It worked.")
 
-print(str(cluster_api.get_cluster_external_ips()))
-print("Done.")
+    print(str(cluster_api.get_cluster_external_ips()))
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,6 +1,6 @@
 import urllib3
 
-import isi_sdk_8_0 as isi_sdk
+import isi_sdk_8_1_0 as isi_sdk
 
 import test_constants
 
@@ -16,15 +16,15 @@ configuration.host = test_constants.HOST
 
 # configure client connection
 api_client = isi_sdk.ApiClient(configuration)
-clusterApi = isi_sdk.ClusterApi(api_client)
+cluster_api = isi_sdk.ClusterApi(api_client)
 
 # these two end points were throwing exceptions before so just testing that
 # they have any response at all for now.
-print(str(clusterApi.get_cluster_config()))
+print(str(cluster_api.get_cluster_config()))
 print("It worked.")
 
-print(str(clusterApi.get_cluster_version()))
+print(str(cluster_api.get_cluster_version()))
 print("It worked.")
 
-print(str(clusterApi.get_cluster_external_ips()))
+print(str(cluster_api.get_cluster_external_ips()))
 print("Done.")

--- a/tests/test_cluster_timezone.py
+++ b/tests/test_cluster_timezone.py
@@ -7,19 +7,24 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-clusterApi = isi_sdk.ClusterApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    clusterApi = isi_sdk.ClusterApi(api_client)
 
-timezone = clusterApi.get_cluster_timezone()
+    timezone = clusterApi.get_cluster_timezone()
 
-print("TimeZone: " + str(timezone))
+    print("TimeZone: " + str(timezone))
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_cluster_timezone.py
+++ b/tests/test_cluster_timezone.py
@@ -1,20 +1,25 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-clusterApi = isi_sdk.ClusterApi(apiClient)
+
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+clusterApi = isi_sdk.ClusterApi(api_client)
 
 timezone = clusterApi.get_cluster_timezone()
 
-print "TimeZone: " + str(timezone)
+print("TimeZone: " + str(timezone))
 
-print "Done."
+print("Done.")

--- a/tests/test_event_eventgroup_ocurrences.py
+++ b/tests/test_event_eventgroup_ocurrences.py
@@ -1,28 +1,33 @@
 import urllib3
 
-import isi_sdk_8_0 as isi_sdk
+import isi_sdk_8_1_0 as isi_sdk
 
 import test_constants
 
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-eventApi = isi_sdk.EventApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    eventApi = isi_sdk.EventApi(api_client)
 
-resp = eventApi.get_event_eventgroup_occurrences()
+    resp = eventApi.get_event_eventgroup_occurrences()
 
-# This is broken in 8.0
-if resp.total > 1 and resp.eventgroups and isinstance(resp.eventgroups, list):
-    print("Received back %d eventgroups." % len(resp.eventgroups))
-else:
-    print(str(resp))
-    print("Failed.")
+    if (resp.total > 1 and resp.eventgroups and
+            isinstance(resp.eventgroups, list)):
+        print("Received back %d eventgroups." % len(resp.eventgroups))
+    else:
+        print(str(resp))
+        print("Failed.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_event_eventgroup_ocurrences.py
+++ b/tests/test_event_eventgroup_ocurrences.py
@@ -1,26 +1,28 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-eventApi = isi_sdk.EventApi(apiClient)
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+eventApi = isi_sdk.EventApi(api_client)
 
 resp = eventApi.get_event_eventgroup_occurrences()
-print "It worked."
+
 # This is broken in 8.0
-#if resp.total > 1 \
-#        and type(resp.eventgroup_occurrences) == list \
-#        and len(resp.eventgroup_occurrences) > 0:
-#    print "It worked."
-#else:
-#    print str(resp)
-#    print "Failed."
+if resp.total > 1 and resp.eventgroups and isinstance(resp.eventgroups, list):
+    print("Received back %d eventgroups." % len(resp.eventgroups))
+else:
+    print(str(resp))
+    print("Failed.")

--- a/tests/test_network_groupnets.py
+++ b/tests/test_network_groupnets.py
@@ -1,28 +1,28 @@
-import isi_sdk as isi_sdk
-from isi_sdk.rest import ApiException
 import urllib3
-import test_constants
 
-from pprint import pprint
+import isi_sdk_8_0 as isi_sdk
+from isi_sdk_8_0.rest import ApiException
+
+import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-api_client = isi_sdk.ApiClient(host)
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
 api_instance = isi_sdk.NetworkGroupnetsApi(api_client)
 
 try:
-
     api_response = \
-            api_instance.list_subnets_subnet_pools('groupnet0', 'subnet0')
-    pprint(api_response)
+        api_instance.list_subnets_subnet_pools('groupnet0', 'subnet0')
+    print(api_response)
 
 except ApiException as e:
-
-    print "Exception when calling list_subnets_subnet_pools: %s\n" % e
+    print("Exception when calling list_subnets_subnet_pools: %s\n" % e)

--- a/tests/test_network_groupnets.py
+++ b/tests/test_network_groupnets.py
@@ -8,21 +8,26 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-api_instance = isi_sdk.NetworkGroupnetsApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    api_instance = isi_sdk.NetworkGroupnetsApi(api_client)
 
-try:
-    api_response = \
-        api_instance.list_subnets_subnet_pools('groupnet0', 'subnet0')
-    print(api_response)
+    try:
+        api_response = \
+            api_instance.list_subnets_subnet_pools('groupnet0', 'subnet0')
+        print(api_response)
 
-except ApiException as e:
-    print("Exception when calling list_subnets_subnet_pools: %s\n" % e)
+    except ApiException as e:
+        print("Exception when calling list_subnets_subnet_pools: %s\n" % e)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_protocols_nfs.py
+++ b/tests/test_protocols_nfs.py
@@ -1,96 +1,101 @@
 import urllib3
 
-import isi_sdk_8_1_0 as isi_sdk
+import isi_sdk_8_0_1 as isi_sdk
 
 import test_constants
 
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-protocols_api = isi_sdk.ProtocolsApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    protocols_api = isi_sdk.ProtocolsApi(api_client)
 
-nfs_netgroup_settings = isi_sdk.NfsNetgroupSettings()
-nfs_netgroup_settings.retry = 50
-nfs_netgroup = isi_sdk.NfsNetgroup()
-nfs_netgroup.settings = nfs_netgroup_settings
+    nfs_netgroup_settings = isi_sdk.NfsNetgroupSettings()
+    nfs_netgroup_settings.retry = 50
+    nfs_netgroup = isi_sdk.NfsNetgroup()
+    nfs_netgroup.settings = nfs_netgroup_settings
 
-protocols_api.update_nfs_netgroup(nfs_netgroup)
+    protocols_api.update_nfs_netgroup(nfs_netgroup)
 
-test_nfs_netgroup = protocols_api.get_nfs_netgroup()
+    test_nfs_netgroup = protocols_api.get_nfs_netgroup()
 
-if test_nfs_netgroup.settings.retry != nfs_netgroup.settings.retry:
-    raise RuntimeError("Netgroup Update Failed")
+    if test_nfs_netgroup.settings.retry != nfs_netgroup.settings.retry:
+        raise RuntimeError("Netgroup Update Failed")
 
-new_nfs_alias = isi_sdk.NfsAliasCreateParams(
-    name="/FStress", path="/ifs/fstress")
-try:
-    protocols_api.create_nfs_alias(new_nfs_alias)
-except isi_sdk.rest.ApiException as err:
-    if err.status == 409:
-        print("Alias already exists")
-    else:
-        raise err
+    new_nfs_alias = isi_sdk.NfsAliasCreateParams(
+        name="/FStress", path="/ifs/fstress")
+    try:
+        protocols_api.create_nfs_alias(new_nfs_alias)
+    except isi_sdk.rest.ApiException as err:
+        if err.status == 409:
+            print("Alias already exists")
+        else:
+            raise err
 
-nfs_aliases = protocols_api.list_nfs_aliases()
-for nfs_alias in nfs_aliases.aliases:
-    nfs_alias = protocols_api.get_nfs_alias(nfs_alias.id)
-    print("NFS Alias: " + str(nfs_alias))
+    nfs_aliases = protocols_api.list_nfs_aliases()
+    for nfs_alias in nfs_aliases.aliases:
+        nfs_alias = protocols_api.get_nfs_alias(nfs_alias.id)
+        print("NFS Alias: " + str(nfs_alias))
 
-protocols_api.delete_nfs_alias(new_nfs_alias.name)
-print("Deleted alias " + new_nfs_alias.name)
-# get all exports
-nfs_exports = protocols_api.list_nfs_exports()
-print("NFS Exports:\n" + str(nfs_exports))
+    protocols_api.delete_nfs_alias(new_nfs_alias.name)
+    print("Deleted alias " + new_nfs_alias.name)
+    # get all exports
+    nfs_exports = protocols_api.list_nfs_exports()
+    print("NFS Exports:\n" + str(nfs_exports))
 
-# get a specific export by id
-get_export_resp = protocols_api.get_nfs_export(nfs_exports.exports[-1].id)
+    # get a specific export by id
+    get_export_resp = protocols_api.get_nfs_export(nfs_exports.exports[-1].id)
 
-# update it with a PUT
-an_export = get_export_resp.exports[0]
-update_export = isi_sdk.NfsExport()
+    # update it with a PUT
+    an_export = get_export_resp.exports[0]
+    update_export = isi_sdk.NfsExport()
 
-# toggle the symlinks parameter
-update_export.symlinks = an_export.symlinks == False
+    # toggle the symlinks parameter
+    update_export.symlinks = not an_export.symlinks
 
-protocols_api.update_nfs_export(nfs_export_id=an_export.id,
-                                nfs_export=update_export)
+    protocols_api.update_nfs_export(nfs_export_id=an_export.id,
+                                    nfs_export=update_export)
 
-# get it back and check that it worked
-get_export_resp = protocols_api.get_nfs_export(an_export.id)
+    # get it back and check that it worked
+    get_export_resp = protocols_api.get_nfs_export(an_export.id)
 
-if get_export_resp.exports[0].symlinks != update_export.symlinks:
-    raise RuntimeError("Update Failed.")
+    if get_export_resp.exports[0].symlinks != update_export.symlinks:
+        raise RuntimeError("Update Failed.")
 
 
-# create a new export
-new_export = isi_sdk.NfsExport()
-new_export.paths = ["/ifs/data"]
+    # create a new export
+    new_export = isi_sdk.NfsExport()
+    new_export.paths = ["/ifs/data"]
 
-# use force because path already exists as export so would normally fail
-create_resp = protocols_api.create_nfs_export(new_export, force=True)
-print("Created=" + str(create_resp.id))
-# now delete it
-print("Deleting it.")
-protocols_api.delete_nfs_export(nfs_export_id=create_resp.id)
+    # use force because path already exists as export so would normally fail
+    create_resp = protocols_api.create_nfs_export(new_export, force=True)
+    print("Created=" + str(create_resp.id))
+    # now delete it
+    print("Deleting it.")
+    protocols_api.delete_nfs_export(nfs_export_id=create_resp.id)
 
-# verify that it is deleted
-# Note: my Error data model is not correct yet,
-# so get on a non-existent nfs export id throws exception. Ideally it would
-# just return an error response
-try:
-    print("Verifying delete.")
-    resp = protocols_api.get_nfs_export(nfs_export_id=create_resp.id)
-    print("Response should be 404, not: " + str(resp))
-except isi_sdk.rest.ApiException:
-    pass
+    # verify that it is deleted
+    # Note: my Error data model is not correct yet,
+    # so get on a non-existent nfs export id throws exception. Ideally it would
+    # just return an error response
+    try:
+        print("Verifying delete.")
+        resp = protocols_api.get_nfs_export(nfs_export_id=create_resp.id)
+        print("Response should be 404, not: " + str(resp))
+    except isi_sdk.rest.ApiException:
+        pass
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_protocols_nfs.py
+++ b/tests/test_protocols_nfs.py
@@ -1,86 +1,96 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_1_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-protocolsApi = isi_sdk.ProtocolsApi(apiClient)
+
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+protocols_api = isi_sdk.ProtocolsApi(api_client)
 
 nfs_netgroup_settings = isi_sdk.NfsNetgroupSettings()
 nfs_netgroup_settings.retry = 50
 nfs_netgroup = isi_sdk.NfsNetgroup()
 nfs_netgroup.settings = nfs_netgroup_settings
 
-protocolsApi.update_nfs_netgroup(nfs_netgroup)
+protocols_api.update_nfs_netgroup(nfs_netgroup)
 
-test_nfs_netgroup = protocolsApi.get_nfs_netgroup()
+test_nfs_netgroup = protocols_api.get_nfs_netgroup()
 
 if test_nfs_netgroup.settings.retry != nfs_netgroup.settings.retry:
     raise RuntimeError("Netgroup Update Failed")
 
-new_nfs_alias = isi_sdk.NfsAliaseCreateParams()
-new_nfs_alias.name = "/FStress"
-new_nfs_alias.path = "/ifs/fstress"
-protocolsApi.create_nfs_aliase(new_nfs_alias)
+new_nfs_alias = isi_sdk.NfsAliasCreateParams(
+    name="/FStress", path="/ifs/fstress")
+try:
+    protocols_api.create_nfs_alias(new_nfs_alias)
+except isi_sdk.rest.ApiException as err:
+    if err.status == 409:
+        print("Alias already exists")
+    else:
+        raise err
 
-nfs_aliases = protocolsApi.list_nfs_aliases()
+nfs_aliases = protocols_api.list_nfs_aliases()
 for nfs_alias in nfs_aliases.aliases:
-    nfs_alias = protocolsApi.get_nfs_aliase(nfs_alias.id)
-    print "NFS Alias: " + str(nfs_alias)
+    nfs_alias = protocols_api.get_nfs_alias(nfs_alias.id)
+    print("NFS Alias: " + str(nfs_alias))
 
-protocolsApi.delete_nfs_aliase(new_nfs_alias.name)
-print "Deleted alias " + new_nfs_alias.name
+protocols_api.delete_nfs_alias(new_nfs_alias.name)
+print("Deleted alias " + new_nfs_alias.name)
 # get all exports
-nfsExports = protocolsApi.list_nfs_exports()
-print "NFS Exports:\n" + str(nfsExports)
+nfs_exports = protocols_api.list_nfs_exports()
+print("NFS Exports:\n" + str(nfs_exports))
 
 # get a specific export by id
-getExportResp = protocolsApi.get_nfs_export(nfsExports.exports[-1].id)
+get_export_resp = protocols_api.get_nfs_export(nfs_exports.exports[-1].id)
 
 # update it with a PUT
-anExport = getExportResp.exports[0]
-updateExport = isi_sdk.NfsExport()
+an_export = get_export_resp.exports[0]
+update_export = isi_sdk.NfsExport()
 
 # toggle the symlinks parameter
-updateExport.symlinks = anExport.symlinks == False
+update_export.symlinks = an_export.symlinks == False
 
-protocolsApi.update_nfs_export(nfs_export_id=anExport.id,
-                               nfs_export=updateExport)
+protocols_api.update_nfs_export(nfs_export_id=an_export.id,
+                                nfs_export=update_export)
 
 # get it back and check that it worked
-getExportResp = protocolsApi.get_nfs_export(anExport.id)
+get_export_resp = protocols_api.get_nfs_export(an_export.id)
 
-if getExportResp.exports[0].symlinks != updateExport.symlinks:
+if get_export_resp.exports[0].symlinks != update_export.symlinks:
     raise RuntimeError("Update Failed.")
 
 
 # create a new export
-newExport = isi_sdk.NfsExport()
-newExport.paths = ["/ifs/data"]
+new_export = isi_sdk.NfsExport()
+new_export.paths = ["/ifs/data"]
 
 # use force because path already exists as export so would normally fail
-createResp = protocolsApi.create_nfs_export(newExport, force=True)
-print "Created=" + str(createResp.id)
+create_resp = protocols_api.create_nfs_export(new_export, force=True)
+print("Created=" + str(create_resp.id))
 # now delete it
-print "Deleting it."
-protocolsApi.delete_nfs_export(nfs_export_id=createResp.id)
+print("Deleting it.")
+protocols_api.delete_nfs_export(nfs_export_id=create_resp.id)
 
 # verify that it is deleted
 # Note: my Error data model is not correct yet,
 # so get on a non-existent nfs export id throws exception. Ideally it would
 # just return an error response
 try:
-    print "Verifying delete."
-    resp = protocolsApi.get_nfs_export(nfs_export_id=createResp.id)
-    print "Response should be 404, not: " + str(resp)
+    print("Verifying delete.")
+    resp = protocols_api.get_nfs_export(nfs_export_id=create_resp.id)
+    print("Response should be 404, not: " + str(resp))
 except isi_sdk.rest.ApiException:
     pass
 
-print "Done."
+print("Done.")

--- a/tests/test_protocols_smb.py
+++ b/tests/test_protocols_smb.py
@@ -8,85 +8,75 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-protocols_api = isi_sdk.ProtocolsApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    protocols_api = isi_sdk.ProtocolsApi(api_client)
 
-# get all shares
-smb_shares = protocols_api.list_smb_shares()
-print("SMB Shares:\n" + str(smb_shares))
+    # get all shares
+    smb_shares = protocols_api.list_smb_shares()
+    print("SMB Shares:\n" + str(smb_shares))
 
-# get a specific share by id
-get_share_resp = protocols_api.get_smb_share(smb_shares.shares[-1].id)
+    # get a specific share by id
+    get_share_resp = protocols_api.get_smb_share(smb_shares.shares[-1].id)
 
-# update it with a PUT
-a_share = get_share_resp.shares[0]
-# the data model returned by the get_smb_share is not compatible with the data
-# model required by a PUT and/or POST (there extra information in the response
-# from the "GET" queries, which when the same object/data model is used in a
-# PUT or POST the PAPI gives an error. So we have to define/create new objects.
-# NOTE: There's actually an ApiClient::__deserialize_model function that can
-# build an object from a dict, which would allow the different data models to
-# translate between each other, e.g.:
-# update_share =
-#     api_client.__deserializeModel(a_share.to_dict(), isi_sdk.SmbShare)
-# its too bad that the data models don't directly support construction from a
-# dict (seems easy enough considering they support "to_dict", might as well
-# support "from_dict", perhaps can request a new Swagger feature. Although,
-# ideally the Isilon PAPI data models were consistent or at least weren't so
-# strict about extra data.
-update_share = isi_sdk.SmbShare()
+    # update it with a PUT
+    a_share = get_share_resp.shares[0]
+    update_share = isi_sdk.SmbShare()
 
-# toggle the browsable parameter
-update_share.browsable = not a_share.browsable
+    # toggle the browsable parameter
+    update_share.browsable = not a_share.browsable
 
-protocols_api.update_smb_share(smb_share_id=a_share.id,
-                               smb_share=update_share)
+    protocols_api.update_smb_share(smb_share_id=a_share.id,
+                                   smb_share=update_share)
 
-# get it back and check that it worked
-get_share_resp = protocols_api.get_smb_share(a_share.id)
+    # get it back and check that it worked
+    get_share_resp = protocols_api.get_smb_share(a_share.id)
 
-print("It worked == " +
-      str(get_share_resp.shares[0].browsable == update_share.browsable))
+    print("It worked == " +
+          str(get_share_resp.shares[0].browsable == update_share.browsable))
 
-# create a new share
-new_share = isi_sdk.SmbShareCreateParams(name="ifs_data", path="/ifs/data")
+    # create a new share
+    new_share = isi_sdk.SmbShareCreateParams(name="ifs_data", path="/ifs/data")
 
-try:
-    create_resp = protocols_api.create_smb_share(new_share)
-except isi_sdk.rest.ApiException as err:
-    if err.status == 409:
-        print(json.loads(err.body)['errors'][0]['message'])
-        # share already exists, so look it up
-        for share in protocols_api.list_smb_shares().shares:
-            if share.name == new_share.name:
-                share_id = share.id
+    try:
+        create_resp = protocols_api.create_smb_share(new_share)
+    except isi_sdk.rest.ApiException as err:
+        if err.status == 409:
+            print(json.loads(err.body)['errors'][0]['message'])
+            # share already exists, so look it up
+            for share in protocols_api.list_smb_shares().shares:
+                if share.name == new_share.name:
+                    share_id = share.id
+        else:
+            raise err
     else:
-        raise err
-else:
-    share_id = create_resp.id
-    print("Created=" + str(share_id))
+        share_id = create_resp.id
+        print("Created=" + str(share_id))
 
-# now delete it
-print("Deleting it.")
-protocols_api.delete_smb_share(smb_share_id=share_id)
+    # now delete it
+    print("Deleting it.")
+    protocols_api.delete_smb_share(smb_share_id=share_id)
 
-# verify that it is deleted
-# Note: my Error data model is not correct yet,
-# so get on a non-existent smb share id throws exception. Ideally it would
-# just return an error response
-try:
-    print("Verifying delete.")
-    resp = protocols_api.get_smb_share(smb_share_id=share_id)
-    print("Response should be 404, not: " + str(resp))
-except isi_sdk.rest.ApiException:
-    pass
+    # verify that it is deleted
+    try:
+        print("Verifying delete.")
+        protocols_api.get_smb_share(smb_share_id=share_id)
+    except isi_sdk.rest.ApiException as err:
+        if err.status == 404:
+            print("Delete verified")
+        else:
+            print(err)
 
-print("Done.")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_protocols_smb.py
+++ b/tests/test_protocols_smb.py
@@ -1,28 +1,33 @@
-import isi_sdk
+import json
 import urllib3
+
+import isi_sdk_8_1_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
 
-# configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-protocolsApi = isi_sdk.ProtocolsApi(apiClient)
+# configure username and password
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
+
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+protocols_api = isi_sdk.ProtocolsApi(api_client)
 
 # get all shares
-smbShares = protocolsApi.list_smb_shares()
-print "SMB Shares:\n" + str(smbShares)
+smb_shares = protocols_api.list_smb_shares()
+print("SMB Shares:\n" + str(smb_shares))
 
 # get a specific share by id
-getShareResp = protocolsApi.get_smb_share(smbShares.shares[-1].id)
+get_share_resp = protocols_api.get_smb_share(smb_shares.shares[-1].id)
 
 # update it with a PUT
-aShare = getShareResp.shares[0]
+a_share = get_share_resp.shares[0]
 # the data model returned by the get_smb_share is not compatible with the data
 # model required by a PUT and/or POST (there extra information in the response
 # from the "GET" queries, which when the same object/data model is used in a
@@ -30,48 +35,58 @@ aShare = getShareResp.shares[0]
 # NOTE: There's actually an ApiClient::__deserialize_model function that can
 # build an object from a dict, which would allow the different data models to
 # translate between each other, e.g.:
-# updateShare =
-#     apiClient.__deserializeModel(aShare.to_dict(),isi_sdk.SmbShare)
+# update_share =
+#     api_client.__deserializeModel(a_share.to_dict(), isi_sdk.SmbShare)
 # its too bad that the data models don't directly support construction from a
 # dict (seems easy enough considering they support "to_dict", might as well
 # support "from_dict", perhaps can request a new Swagger feature. Although,
 # ideally the Isilon PAPI data models were consistent or at least weren't so
 # strict about extra data.
-updateShare = isi_sdk.SmbShare()
+update_share = isi_sdk.SmbShare()
 
 # toggle the browsable parameter
-updateShare.browsable = aShare.browsable == False
+update_share.browsable = not a_share.browsable
 
-protocolsApi.update_smb_share(smb_share_id=aShare.id,
-                              smb_share=updateShare)
+protocols_api.update_smb_share(smb_share_id=a_share.id,
+                               smb_share=update_share)
 
 # get it back and check that it worked
-getShareResp = protocolsApi.get_smb_share(aShare.id)
+get_share_resp = protocols_api.get_smb_share(a_share.id)
 
-print "It worked == " \
-        + str(getShareResp.shares[0].browsable == updateShare.browsable)
+print("It worked == " +
+      str(get_share_resp.shares[0].browsable == update_share.browsable))
 
 # create a new share
-newShare = isi_sdk.SmbShareCreateParams()
-newShare.path = "/ifs/data"
-newShare.name = "ifs_data"
+new_share = isi_sdk.SmbShareCreateParams(name="ifs_data", path="/ifs/data")
 
-# use force because path already exists as share so would normally fail
-createResp = protocolsApi.create_smb_share(newShare)
-print "Created=" + str(createResp.id)
+try:
+    create_resp = protocols_api.create_smb_share(new_share)
+except isi_sdk.rest.ApiException as err:
+    if err.status == 409:
+        print(json.loads(err.body)['errors'][0]['message'])
+        # share already exists, so look it up
+        for share in protocols_api.list_smb_shares().shares:
+            if share.name == new_share.name:
+                share_id = share.id
+    else:
+        raise err
+else:
+    share_id = create_resp.id
+    print("Created=" + str(share_id))
+
 # now delete it
-print "Deleting it."
-protocolsApi.delete_smb_share(smb_share_id=createResp.id)
+print("Deleting it.")
+protocols_api.delete_smb_share(smb_share_id=share_id)
 
 # verify that it is deleted
 # Note: my Error data model is not correct yet,
 # so get on a non-existent smb share id throws exception. Ideally it would
 # just return an error response
 try:
-    print "Verifying delete."
-    resp = protocolsApi.get_smb_share(smb_share_id=createResp.id)
-    print "Response should be 404, not: " + str(resp)
+    print("Verifying delete.")
+    resp = protocols_api.get_smb_share(smb_share_id=share_id)
+    print("Response should be 404, not: " + str(resp))
 except isi_sdk.rest.ApiException:
     pass
 
-print "Done."
+print("Done.")

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -7,30 +7,35 @@ import test_constants
 urllib3.disable_warnings()
 
 
-# configure username and password
-configuration = isi_sdk.Configuration()
-configuration.username = test_constants.USERNAME
-configuration.password = test_constants.PASSWORD
-configuration.verify_ssl = test_constants.VERIFY_SSL
-configuration.host = test_constants.HOST
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
 
-# configure client connection
-api_client = isi_sdk.ApiClient(configuration)
-quota_api = isi_sdk.QuotaApi(api_client)
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    quota_api = isi_sdk.QuotaApi(api_client)
 
-new_quota = isi_sdk.QuotaQuotaCreateParams(
-    enforced=False,
-    include_snapshots=False,
-    thresholds_include_overhead=False,
-    path="/ifs/data",
-    type="directory")
+    new_quota = isi_sdk.QuotaQuotaCreateParams(
+        enforced=False,
+        include_snapshots=False,
+        thresholds_include_overhead=False,
+        path="/ifs/data",
+        type="directory")
 
-create_resp = quota_api.create_quota_quota(quota_quota=new_quota)
-print("Created=" + str(create_resp))
+    create_resp = quota_api.create_quota_quota(quota_quota=new_quota)
+    print("Created=" + str(create_resp))
 
-print(str(quota_api.list_quota_quotas()))
+    print(str(quota_api.list_quota_quotas()))
 
-delete_resp = quota_api.delete_quota_quotas(path=new_quota.path)
-print(str(delete_resp))
+    delete_resp = quota_api.delete_quota_quotas(path=new_quota.path)
+    print("Delete response=" + str(delete_resp))
 
-print("It worked.")
+    print("It worked.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -1,32 +1,36 @@
-import isi_sdk
 import urllib3
+
+import isi_sdk_8_1_0 as isi_sdk
+
 import test_constants
 
 urllib3.disable_warnings()
 
+
 # configure username and password
-isi_sdk.configuration.username = test_constants.USERNAME
-isi_sdk.configuration.password = test_constants.PASSWORD
-isi_sdk.configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration = isi_sdk.Configuration()
+configuration.username = test_constants.USERNAME
+configuration.password = test_constants.PASSWORD
+configuration.verify_ssl = test_constants.VERIFY_SSL
+configuration.host = test_constants.HOST
 
-# configure host
-host = test_constants.HOST
-apiClient = isi_sdk.ApiClient(host)
-quotaApi = isi_sdk.QuotaApi(apiClient)
+# configure client connection
+api_client = isi_sdk.ApiClient(configuration)
+quota_api = isi_sdk.QuotaApi(api_client)
 
-newQuota = isi_sdk.QuotaQuotaCreateParams()
-newQuota.enforced = False
-newQuota.include_snapshots = False
-newQuota.thresholds_include_overhead = False
-newQuota.path = "/ifs/data"
-newQuota.type = "directory"
+new_quota = isi_sdk.QuotaQuotaCreateParams(
+    enforced=False,
+    include_snapshots=False,
+    thresholds_include_overhead=False,
+    path="/ifs/data",
+    type="directory")
 
-createResp = quotaApi.create_quota_quota(quota_quota=newQuota)
-print "Created=" + str(createResp)
+create_resp = quota_api.create_quota_quota(quota_quota=new_quota)
+print("Created=" + str(create_resp))
 
-print str(quotaApi.list_quota_quotas())
+print(str(quota_api.list_quota_quotas()))
 
-deleteResp = quotaApi.delete_quota_quotas(path=newQuota.path)
-print str(deleteResp)
+delete_resp = quota_api.delete_quota_quotas(path=new_quota.path)
+print(str(delete_resp))
 
-print "It worked."
+print("It worked.")

--- a/tests/unit_test_config_generator.py
+++ b/tests/unit_test_config_generator.py
@@ -371,7 +371,7 @@ class TestCreateSwaggerConfig(unittest.TestCase):
             'type': 'object'
         }
         csc.isi_schema_to_swagger_object(
-            'EventEventgroupOccurrences', 'Eventgroup-Occurrence',
+            'EventEventgroupOccurrences', 'Eventgroup',
             isi_schema, 'Extended')
 
         expected = {


### PR DESCRIPTION
The PR updates the example test scripts and resolves a few bugs that they uncovered.

- The example SDK test scripts have all been updated according to the new API from Swagger Codegen v2.3.1, which requires that the configuration be passed as an argument when instantiating the `ApiClient` class.
- The insufficient fix for OneFS 8.1.0 support here https://github.com/Isilon/isilon_sdk/pull/35 has been addressed by removing the default error response object higher up in the stack. I encountered some response types that were arrays, rather than objects, which were not being handled correctly before. This should ensure that the `isi_sdk_8_1_0` package no longer has regressions.
- Excessive max integer sizes of an unsigned long 64-bit integer have been capped at a max signed 64-bit integer size to avoid integer overflow in Python.
- The top level field name in the events response object was incorrectly being reported as `eventgroup-occurrences` in the PAPI describe message, when in reality, the response object uses `eventgroups`. This is now being corrected.
