### PR TITLE
Resolve Issue #4

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -543,6 +543,14 @@ def isi_schema_to_swagger_object(isi_obj_name_space, isi_obj_name,
             if prop_name == 'type' and 'heartbeat' not in prop['enum']:
                 prop['enum'].append('heartbeat')
                 log.warning("Include missing 'heartbeat' in enum")
+        elif sub_obj_namespace == 'SmbLogLevelFiltersFilter':
+            if prop_name == 'level' and 'enum' in prop:
+                del prop['enum']
+                log.warning("Removing enum with duplicate values")
+        elif 'FileMatchingPattern' in sub_obj_namespace:
+            if prop_name == 'operator' and 'enum' in prop:
+                del prop['enum']
+                log.warning("Removing enum with special characters")
 
         if 'type' not in prop:
             if 'enum' in prop:


### PR DESCRIPTION
Resolves issue #4 by removing problematic enums from the Swagger config. The result of this change is that some invalid strings will not be caught on the client side by the SDK language bindings, but they should still be caught on the server side by the OneFS Platform API.

The `FileMatchingPattern` models used special characters in their enums, which was problematic for languages such as Java that require variable names to start with a letter of the alphabet, an underscore (i.e. `_`), or a dollar sign (i.e. `$`). Furthermore, the `SmbLogLevelFiltersFilter` model had equivalent strings in the enum in both uppercase and lowercase. When all of the enum values were converted to uppercase to match language naming conventions, then duplicates were encountered.

