### PR TITLE
Support for RESTful access to namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Isilon Software Development Kit (isi-sdk)
 Language bindings for the OneFS API and tools for building them
 
-This repository is part of the Isilon SDK.  It includes language bindings for easier programmatic access to the OneFS API for cluster configuration (on your cluster this is the REST API made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or "PAPI").
+This repository is part of the Isilon SDK.  It includes language bindings for easier programmatic access to the OneFS API for cluster configuration (on your cluster this is the REST API made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or "PAPI"). The SDK also includes language bindings for the OneFS RAN (i.e. RESTful Access to Namespace) interface, which provides access to the OneFS filesystem namespace.
 
 You can download the language bindings for Python from the "releases" page of this repo (the link is on the main "code" tab on the bar of links just below the project description). If you just want to access PAPI more easily from your Python programs, these language bindings may be all you need, and you can follow the instructions and example below to get started.
 
@@ -24,6 +24,7 @@ This repository also includes tools to build PAPI bindings yourself for a large 
 
 | Cluster Version       | Install Instruction         |
 |-----------------------|-----------------------------|
+| OneFS 8.1.1 and later | `pip install isi_sdk_8_1_1` |
 | OneFS 8.1.0 and later | `pip install isi_sdk_8_1_0` |
 | OneFS 8.0.1 and later | `pip install isi_sdk_8_0_1` |
 | OneFS 8.0 and later   | `pip install isi_sdk_8_0`   |
@@ -34,6 +35,8 @@ Installation will default to using binary distribution wheel (i.e. bdist). Sourc
 ### Basic Usage
 
 See the generated packages on PyPI for example code:
+
+[isi\_sdk\_8\_1\_1](https://pypi.org/pypi/isi-sdk-8-1-1)
 
 [isi\_sdk\_8\_1\_0](https://pypi.org/pypi/isi-sdk-8-1-0)
 

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -1377,48 +1377,18 @@ def main():
         'definitions': {}
     }
 
+    schemas_dir = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), 'papi_schemas'))
+    defs_file = os.path.join(schemas_dir, 'definitions.json')
+    namespace_file = os.path.join(schemas_dir, 'namespace.json')
+
     if args.defs_file:
-        with open(args.defs_file, 'r') as def_file:
-            SWAGGER_DEFS.update(json.loads(def_file.read()))
-    else:
-        SWAGGER_DEFS.update({
-            'Error': {
-                'type': 'object',
-                'required': [
-                    'code',
-                    'message'
-                ],
-                'properties': {
-                    'code': {
-                        'type': 'integer',
-                        'format': 'int32'
-                    },
-                    'message': {
-                        'type': 'string'
-                    }
-                }
-            },
-            'Empty': {
-                'type': 'object',
-                'properties': {}
-            },
-            'CreateResponse': {
-                'properties': {
-                    'id': {
-                        'description': ('ID of created item that can be used '
-                                        'to refer to item in the collection-'
-                                        'item resource path.'),
-                        'maxLength': 255,
-                        'minLength': 0,
-                        'type': 'string'
-                    }
-                },
-                'required': [
-                    'id'
-                ],
-                'type': 'object'
-            }
-        })
+        defs_file = args.defs_file
+
+    with open(defs_file, 'r') as def_file:
+        SWAGGER_DEFS.update(json.loads(def_file.read()))
+    with open(namespace_file, 'r') as namespace_paths:
+        swagger_json['paths'] = json.loads(namespace_paths.read())
 
     swagger_json['definitions'] = SWAGGER_DEFS
 
@@ -1436,8 +1406,6 @@ def main():
         onefs_version = args.onefs_version
 
     cached_schemas = {}
-    schemas_dir = os.path.abspath(os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), 'papi_schemas'))
     schemas_file = os.path.join(schemas_dir, '{}.json'.format(onefs_version))
 
     if args.onefs_version:

--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -964,7 +964,7 @@ def parse_path_params(end_point_path):
     return params
 
 
-def get_endpoint_paths(source_node_or_cluster, papi_port, base_url, auth,
+def get_endpoint_paths(source_node_or_cluster, port, base_url, auth,
                        exclude_end_points, cached_schemas):
     """
     Gets the full list of PAPI URIs reported by source_node_or_cluster using
@@ -975,7 +975,7 @@ def get_endpoint_paths(source_node_or_cluster, papi_port, base_url, auth,
     """
     if 'directory' not in cached_schemas:
         desc_list_parms = {'describe': '', 'json': '', 'list': ''}
-        url = 'https://' + source_node_or_cluster + ':' + papi_port + base_url
+        url = 'https://' + source_node_or_cluster + ':' + port + base_url
         resp = requests.get(
             url=url, params=desc_list_parms, auth=auth, verify=False)
         end_point_list_json = resp.json()['directory']
@@ -1324,26 +1324,26 @@ def main():
         description='Builds Swagger config from PAPI end point descriptions.')
     argparser.add_argument(
         '-i', '--input', dest='host',
-        help='IP-address or hostname of the Isilon cluster to use as input.',
+        help='IP-address or hostname of OneFS cluster for input',
         action='store', default='localhost')
     argparser.add_argument(
         '-o', '--output', dest='output_file',
-        help='Path to the output file.', action='store')
+        help='Path to output OpenAPI specification', action='store')
     argparser.add_argument(
         '-u', '--username', dest='username',
-        help='The username to use for the cluster.',
+        help='Username for cluster access',
         action='store', default=None)
     argparser.add_argument(
         '-p', '--password', dest='password',
-        help='The password to use for the cluster.',
+        help='Password for cluster access',
         action='store', default=None)
     argparser.add_argument(
         '-d', '--defs', dest='defs_file',
-        help='Path to file with pre-built Swagger data model definitions.',
+        help='Path to file with pre-built OpenAPI definitions',
         action='store', default=None)
     argparser.add_argument(
         '-t', '--test', dest='test',
-        help='Test mode on.', action='store_true', default=False)
+        help='Test mode on', action='store_true', default=False)
     argparser.add_argument(
         '-l', '--logging', dest='log_level',
         help='Logging verbosity level', action='store', default='INFO')
@@ -1361,7 +1361,7 @@ def main():
     if not args.onefs_version:
         if args.username is None:
             args.username = raw_input(
-                'Please provide username used to access {} via PAPI: '.format(
+                'Please provide username used for API access to {}: '.format(
                     args.host))
         if args.password is None:
             args.password = getpass.getpass('Password: ')
@@ -1423,11 +1423,11 @@ def main():
 
     auth = HTTPBasicAuth(args.username, args.password)
     base_url = '/platform'
-    papi_port = '8080'
+    port = '8080'
     desc_parms = {'describe': '', 'json': ''}
 
     if not args.onefs_version:
-        onefs_version = onefs_release_version(args.host, papi_port, auth)
+        onefs_version = onefs_release_version(args.host, port, auth)
     else:
         if not re.match(r'^\d{,2}.\d.\d.\d{,2}$', args.onefs_version):
             raise RuntimeError('Invalid ONEFS_VERSION argument: {}'.format(
@@ -1442,7 +1442,7 @@ def main():
             cached_schemas = json.loads(schemas.read())
         papi_version = cached_schemas['version']
     else:
-        papi_version = onefs_papi_version(args.host, papi_port, auth)
+        papi_version = onefs_papi_version(args.host, port, auth)
         # invalid backport of handlers caused versioning break
         if papi_version == '5' and onefs_version[:5] == '8.0.1':
             papi_version = '4'
@@ -1498,7 +1498,7 @@ def main():
             ]
 
         end_point_paths = get_endpoint_paths(
-            args.host, papi_port, base_url, auth, exclude_end_points,
+            args.host, port, base_url, auth, exclude_end_points,
             cached_schemas)
     else:
         exclude_end_points = []
@@ -1531,7 +1531,7 @@ def main():
 
             if not args.onefs_version:
                 url = 'https://{}:{}{}{}'.format(
-                    args.host, papi_port, base_url, item_end_point_path)
+                    args.host, port, base_url, item_end_point_path)
                 resp = requests.get(
                     url=url, params=desc_parms, auth=auth, verify=False)
                 item_resp_json = resp.json()
@@ -1568,7 +1568,7 @@ def main():
 
             if not args.onefs_version:
                 url = 'https://{}:{}{}{}'.format(
-                    args.host, papi_port, base_url, base_end_point_path)
+                    args.host, port, base_url, base_end_point_path)
                 resp = requests.get(
                     url=url, params=desc_parms, auth=auth, verify=False)
                 base_resp_json = resp.json()

--- a/papi_schemas/definitions.json
+++ b/papi_schemas/definitions.json
@@ -1,0 +1,314 @@
+{
+    "Error": {
+        "type": "object",
+        "required": [
+            "code",
+            "message"
+        ],
+        "properties": {
+            "code": {
+                "type": "integer",
+                "format": "int32"
+            },
+            "message": {
+                "type": "string"
+            }
+        }
+    },
+    "Empty": {
+        "type": "object",
+        "properties": {}
+    },
+    "CreateResponse": {
+        "properties": {
+            "id": {
+                "description": "ID of created item that can be used to refer to item in the collection-item resource path.",
+                "maxLength": 255,
+                "minLength": 0,
+                "type": "string"
+            }
+        },
+        "required": [
+            "id"
+        ],
+        "type": "object"
+    },
+    "NamespaceAccessPoints": {
+        "properties": {
+            "namespaces": {
+                "items": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "minItems": 0,
+                "type": "array"
+            },
+            "versions": {
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 0,
+                "type": "array"
+            }
+        },
+        "type": "object"
+    },
+    "NamespaceObject": {
+        "properties": {
+            "name": {
+                "description": "Specifies the name of the object.",
+                "type": "string"
+            },
+            "size": {
+                "description": "Specifies the size of the object in bytes.",
+                "type": "integer"
+            },
+            "block_size": {
+                "description": "Specifies the block size of the object.",
+                "type": "integer"
+            },
+            "blocks": {
+                "description": "Specifies the number of blocks that compose the object.",
+                "type": "integer"
+            },
+            "last_modified": {
+                "description": "Specifies the time when the object data was last modified in HTTP date/time format.",
+                "type": "string"
+            },
+            "create_time": {
+                "description": "Specifies the date when the object data was created in HTTP date/time format.",
+                "type": "string"
+            },
+            "access_time": {
+                "description": "Specifies the date when the object was last accessed in HTTP date/time format.",
+                "type": "string"
+            },
+            "change_time": {
+                "description": "Specifies the date when the object was last changed (including data and metadata changes) in HTTP date/time format.",
+                "type": "string"
+            },
+            "type": {
+                "description": "Specifies the object type, which can be one of the following values: container, object, pipe, character_device, block_device, symbolic_link, socket, or whiteout_file.",
+                "type": "string"
+            },
+            "mtime_val": {
+                "description": "Specifies the time when the object data was last modified in UNIX Epoch format.",
+                "type": "integer"
+            },
+            "btime_val": {
+                "description": "Specifies the time when the object data was created in UNIX Epoch format.",
+                "type": "integer"
+            },
+            "atime_val": {
+                "description": "Specifies the time when the object was last accessed in UNIX Epoch format.",
+                "type": "integer"
+            },
+            "ctime_val": {
+                "description": "Specifies the time when the object was last changed (including data and metadata changes) in UNIX Epoch format.",
+                "type": "integer"
+            },
+            "owner": {
+                "description": "Specifies the user name for the owner of the object.",
+                "type": "string"
+            },
+            "group": {
+                "description": "Specifies the group name for the owner of the object.",
+                "type": "string"
+            },
+            "uid": {
+                "description": "Specifies the UID for the owner.",
+                "type": "integer"
+            },
+            "gid": {
+                "description": "Specifies the GID for the owner.",
+                "type": "integer"
+            },
+            "mode": {
+                "description": "Specifies the UNIX mode octal number.",
+                "type": "string"
+            },
+            "id": {
+                "description": "Specifies the object ID, which is also the INODE number.",
+                "type": "integer"
+            },
+            "nlink": {
+                "description": "Specifies the number of hard links to the object.",
+                "type": "integer"
+            },
+            "is_hidden": {
+                "description": "Specifies whether the file is hidden or not.",
+                "type": "boolean"
+            },
+            "stub": {
+                "type": "boolean"
+            }
+        },
+        "type": "object"
+    },
+    "NamespaceObjects": {
+        "properties": {
+            "children": {
+                "items": {
+                    "$ref": "#/definitions/NamespaceObject"
+                },
+                "minItems": 0,
+                "type": "array"
+            },
+            "resume": {"type": "string"}
+        },
+        "type": "object"
+    },
+    "NamespaceAccessPoint": {
+        "properties": {
+            "acl": {
+                "description": "Provides the JSON array of access rights.",
+                "items": {
+                    "$ref": "#/definitions/AclObject"
+                },
+                "minItems": 0,
+                "type": "array"
+            },
+            "authoritative": {
+                "description": "If the directory has access rights set, then this field is returned as acl. If the directory has POSIX permissions set, then this field is returned as mode.",
+                "type": "string"
+            },
+            "mode": {
+                "description": "Provides the POSIX mode.",
+                "type": "string"
+            },
+            "group": {
+                "$ref": "#/definitions/MemberObject",
+                "description": "Provides the JSON object for the group persona of the owner."
+            },
+            "owner": {
+                "$ref": "#/definitions/MemberObject",
+                "description": "Provides the JSON object for the owner persona."
+            }
+        },
+        "type": "object"
+    },
+    "AclObject": {
+        "properties": {
+            "trustee": {
+                "$ref": "#/definitions/MemberObject"
+            },
+            "accesstype": {
+                "type": "string"
+            },
+            "accessrights": {
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 0,
+                "type": "array"
+            },
+            "op": {
+                "type": "string"
+            },
+            "inherit_flags": {
+                "items": {
+                    "type": "boolean"
+                },
+                "minItems": 0,
+                "type": "array"
+            }
+        },
+        "type": "object"
+    },
+    "MemberObject": {
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            }
+        },
+        "type": "object"
+    },
+    "ObjectMetadata": {
+        "properties": {
+            "action": {
+                "type": "string"
+            },
+            "attrs": {
+                "items": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "op": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "type": "array"
+            }
+        },
+        "type": "object"
+    },
+    "ObjectMetadataList": {
+        "properties": {
+            "attrs": {
+                "items": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "type": "array"
+            }
+        },
+        "type": "object"
+    },
+    "CopyErrors": {
+        "properties": {
+            "copy_errors": {
+                "items": {
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        },
+                        "error_src": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "type": "array"
+            }
+        },
+        "type": "object"
+    }
+}

--- a/papi_schemas/definitions.json
+++ b/papi_schemas/definitions.json
@@ -33,6 +33,18 @@
         ],
         "type": "object"
     },
+    "AccessPointCreateParams": {
+        "properties": {
+            "path": {
+                "description": "Absolute file system path of access point.",
+                "type": "string"
+            }
+        },
+        "required": [
+            "path"
+        ],
+        "type": "object"
+    },
     "NamespaceAccessPoints": {
         "properties": {
             "namespaces": {
@@ -161,11 +173,13 @@
                 "minItems": 0,
                 "type": "array"
             },
-            "resume": {"type": "string"}
+            "resume": {
+                "type": "string"
+            }
         },
         "type": "object"
     },
-    "NamespaceAccessPoint": {
+    "NamespaceAcl": {
         "properties": {
             "acl": {
                 "description": "Provides the JSON array of access rights.",
@@ -236,7 +250,7 @@
         },
         "type": "object"
     },
-    "ObjectMetadata": {
+    "NamespaceMetadata": {
         "properties": {
             "action": {
                 "type": "string"
@@ -264,7 +278,7 @@
         },
         "type": "object"
     },
-    "ObjectMetadataList": {
+    "NamespaceMetadataList": {
         "properties": {
             "attrs": {
                 "items": {
@@ -307,6 +321,97 @@
                     "type": "object"
                 },
                 "type": "array"
+            }
+        },
+        "type": "object"
+    },
+    "DirectoryQuery": {
+        "properties": {
+            "result": {
+                "items": {
+                    "type": "string"
+                },
+                "type": "array"
+            },
+            "scope": {
+                "properties": {
+                    "logic": {
+                        "type": "string"
+                    },
+                    "conditions": {
+                        "items": {
+                            "properties": {
+                                "operator": {
+                                    "type": "string"
+                                },
+                                "attr": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "type": "object"
+    },
+    "WormProperties": {
+        "properties": {
+            "worm_committed": {
+                "description": "Indicates whether the file was committed to the WORM state.",
+                "type": "boolean"
+            },
+            "worm_retention_date": {
+                "description": "Provides the retention expiration date in Coordinated Universal Time (such as UTC/GMT).",
+                "type": "string"
+            },
+            "worm_retention_date_val": {
+                "description": "Provides the retention expiration date in seconds from UNIX Epoch or UTC.",
+                "type": "integer"
+            },
+            "worm_override_retention_date": {
+                "description": "Provides the override retention date that is set on the SmartLock directory where the file resides.",
+                "type": "string"
+            },
+            "worm_override_retention_date_val": {
+                "description": "Provides the override retention date in seconds from UNIX Epoch or UTC.",
+                "type": "integer"
+            },
+            "autocommit_delay": {
+                "description": "Autocommit delay.",
+                "type": "integer"
+            },
+            "domain_id": {
+                "description": "WORM domain ID.",
+                "type": "integer"
+            },
+            "domain_path": {
+                "description": "WORM domain path.",
+                "type": "string"
+            },
+            "worm_ctime": {
+                "description": "WORM change time.",
+                "type": "integer"
+            }
+        },
+        "type": "object"
+    },
+    "WormCreateParams": {
+        "properties": {
+            "worm_retention_date": {
+                "description": "Specifies the retention expiration date string in Coordinated Universal Time (UTC/GMT).",
+                "type": "string"
+            },
+            "commit_to_worm": {
+                "default": false,
+                "description": "Specifies whether to commit the file to a WORM state after the retention date is set.",
+                "type": "boolean"
             }
         },
         "type": "object"

--- a/papi_schemas/namespace.json
+++ b/papi_schemas/namespace.json
@@ -1,14 +1,14 @@
 {
     "/namespace": {
         "get": {
-            "description": "List namespace access points.",
+            "description": "Retrieves the namespace access points available for the authenticated user.",
             "operationId": "listAccessPoints",
             "parameters": [
                 {
                     "description": "Protocol versions that are supported for the current namespace access server.",
                     "in": "query",
                     "name": "versions",
-                    "type": "string"
+                    "type": "boolean"
                 }
             ],
             "responses": {
@@ -24,35 +24,34 @@
             ]
         }
     },
-    "/namespace/{AccessPoint}": {
+    "/namespace/{AccessPointName}": {
         "put": {
-            "description": "Create access point.",
+            "description": "Creates a namespace access point in the file system. Only root users can create or change namespace access points.",
             "operationId": "createAccessPoint",
             "parameters": [
                 {
-                    "description": "Access point path.",
+                    "description": "Access point name.",
                     "in": "path",
-                    "name": "AccessPoint",
+                    "name": "AccessPointName",
                     "required": true,
                     "type": "string"
                 },
                 {
+                    "description": "Access point parameters model.",
                     "in": "body",
-                    "name": "AccessPointPath",
+                    "name": "AccessPoint",
                     "required": true,
                     "schema": {
-                        "properties": {
-                            "path": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "#/definitions/AccessPointCreateParams"
                     }
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Created access point."
+                    "description": "Created access point.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
                 }
             },
             "tags": [
@@ -60,20 +59,23 @@
             ]
         },
         "delete": {
-            "description": "Delete access point.",
+            "description": "Deletes a namespace access point. Only root users can delete namespace access points.",
             "operationId": "deleteAccessPoint",
             "parameters": [
                 {
-                    "description": "Access point path.",
+                    "description": "Access point name.",
                     "in": "path",
-                    "name": "AccessPoint",
+                    "name": "AccessPointName",
                     "required": true,
                     "type": "string"
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Deleted access point."
+                    "description": "Deleted access point.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
                 }
             },
             "tags": [
@@ -81,15 +83,15 @@
             ]
         }
     },
-    "/namespace/{AccessPointAcl}": {
+    "/namespace/{NamespacePath}": {
         "get": {
-            "description": "Get access point ACL.",
-            "operationId": "getAccessPointAcl",
+            "description": "Retrieves the access control list for a namespace object.",
+            "operationId": "getNamespaceAcl",
             "parameters": [
                 {
-                    "description": "Access point path.",
+                    "description": "Namespace path relative to /.",
                     "in": "path",
-                    "name": "AccessPointAcl",
+                    "name": "NamespacePath",
                     "required": true,
                     "type": "string"
                 },
@@ -98,21 +100,20 @@
                     "in": "query",
                     "name": "acl",
                     "required": true,
-                    "type": "string"
+                    "type": "boolean"
                 },
                 {
                     "description": "Indicates that the operation is on the access point instead of the store path.",
                     "in": "query",
                     "name": "nsaccess",
-                    "required": true,
                     "type": "boolean"
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Get access point ACL.",
+                    "description": "Get namespace ACL.",
                     "schema": {
-                        "$ref": "#/definitions/NamespaceAccessPoint"
+                        "$ref": "#/definitions/NamespaceAcl"
                     }
                 }
             },
@@ -121,13 +122,13 @@
             ]
         },
         "put": {
-            "description": "Set access point ACL.",
-            "operationId": "setAccessPointAcl",
+            "description": "Sets the access control list for a namespace.",
+            "operationId": "setNamespaceAcl",
             "parameters": [
                 {
-                    "description": "Access point path.",
+                    "description": "Namespace path relative to /.",
                     "in": "path",
-                    "name": "AccessPointAcl",
+                    "name": "NamespacePath",
                     "required": true,
                     "type": "string"
                 },
@@ -136,27 +137,27 @@
                     "in": "query",
                     "name": "acl",
                     "required": true,
-                    "type": "string"
+                    "type": "boolean"
                 },
                 {
                     "description": "Indicates that the operation is on the access point instead of the store path.",
                     "in": "query",
                     "name": "nsaccess",
-                    "required": true,
                     "type": "boolean"
                 },
                 {
+                    "description": "Namespace ACL parameters model.",
                     "in": "body",
-                    "name": "AccessPointAclBody",
+                    "name": "NamespaceAcl",
                     "required": true,
                     "schema": {
-                        "$ref": "#/definitions/NamespaceAccessPoint"
+                        "$ref": "#/definitions/NamespaceAcl"
                     }
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Set access point ACL.",
+                    "description": "Set namespace ACL.",
                     "schema": {
                         "$ref": "#/definitions/Empty"
                     }
@@ -169,11 +170,11 @@
     },
     "/namespace/{DirectoryPath}": {
         "get": {
-            "description": "List directory objects.",
-            "operationId": "listDirectoryObjects",
+            "description": "Retrieves a list of files and subdirectories from a directory.",
+            "operationId": "getDirectoryContents",
             "parameters": [
                 {
-                    "description": "Directory path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryPath",
                     "required": true,
@@ -243,11 +244,11 @@
             ]
         },
         "head": {
-            "description": "Get attribute information for directory.",
+            "description": "Retrieves the attribute information for a specified directory without transferring the contents of the directory.",
             "operationId": "getDirectoryAttributes",
             "parameters": [
                 {
-                    "description": "Directory path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryPath",
                     "required": true,
@@ -293,11 +294,11 @@
             ]
         },
         "put": {
-            "description": "Create directory.",
+            "description": "Creates a directory with a specified path.",
             "operationId": "createDirectory",
             "parameters": [
                 {
-                    "description": "Directory path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryPath",
                     "required": true,
@@ -312,6 +313,7 @@
                     "type": "string"
                 },
                 {
+                    "default": "0700",
                     "description": "Specifies a pre-defined ACL value or POSIX mode with a string in octal string format.",
                     "in": "header",
                     "name": "x-isi-ifs-access-control",
@@ -349,11 +351,11 @@
             ]
         },
         "post": {
-            "description": "Move directory.",
+            "description": "Moves a directory from an existing source to a new destination path.",
             "operationId": "moveDirectory",
             "parameters": [
                 {
-                    "description": "Directory path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryPath",
                     "required": true,
@@ -380,11 +382,11 @@
             ]
         },
         "delete": {
-            "description": "Delete directory.",
+            "description": "Deletes the directory at the specified path.",
             "operationId": "deleteDirectory",
             "parameters": [
                 {
-                    "description": "Directory path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryPath",
                     "required": true,
@@ -399,12 +401,9 @@
             ],
             "responses": {
                 "204": {
-                    "description": "Deleted directory."
-                },
-                "default": {
-                    "description": "Unexpected error",
+                    "description": "Deleted directory.",
                     "schema": {
-                        "$ref": "#/definitions/Error"
+                        "$ref": "#/definitions/Empty"
                     }
                 }
             },
@@ -415,11 +414,11 @@
     },
     "/namespace/{DirectoryMetadataPath}": {
         "get": {
-            "description": "List metadata on a directory.",
-            "operationId": "listDirectoryMetadata",
+            "description": "Retrieves the attribute information for a specified directory with the metadata query argument.",
+            "operationId": "getDirectoryMetadata",
             "parameters": [
                 {
-                    "description": "Directory metadata path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryMetadataPath",
                     "required": true,
@@ -430,14 +429,14 @@
                     "in": "query",
                     "name": "metadata",
                     "required": true,
-                    "type": "string"
+                    "type": "boolean"
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "List directory metadata.",
+                    "description": "Get directory metadata.",
                     "schema": {
-                        "$ref": "#/definitions/ObjectMetadataList"
+                        "$ref": "#/definitions/NamespaceMetadataList"
                     }
                 }
             },
@@ -446,11 +445,11 @@
             ]
         },
         "put": {
-            "description": "Set metadata on a directory.",
+            "description": "Sets attributes on a specified directory with the metadata query argument.",
             "operationId": "setDirectoryMetadata",
             "parameters": [
                 {
-                    "description": "Directory metadata path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
                     "name": "DirectoryMetadataPath",
                     "required": true,
@@ -461,17 +460,15 @@
                     "in": "query",
                     "name": "metadata",
                     "required": true,
-                    "schema": {
-                        "default": "",
-                        "type": "string"
-                    }
+                    "type": "boolean"
                 },
                 {
+                    "description": "Directory metadata parameters model.",
                     "in": "body",
                     "name": "DirectoryMetadata",
                     "required": true,
                     "schema": {
-                        "$ref": "#/definitions/ObjectMetadata"
+                        "$ref": "#/definitions/NamespaceMetadata"
                     }
                 }
             ],
@@ -490,11 +487,11 @@
     },
     "/namespace/{DirectoryCopyDestination}": {
         "put": {
-            "description": "Copy directory.",
+            "description": "Recursively copies a directory to a specified destination path. Symbolic links are copied as regular files.",
             "operationId": "copyDirectory",
             "parameters": [
                 {
-                    "description": "Directory copy destination.",
+                    "description": "Directory copy destination relative to /.",
                     "in": "path",
                     "name": "DirectoryCopyDestination",
                     "required": true,
@@ -541,11 +538,11 @@
     },
     "/namespace/{FilePath}": {
         "get": {
-            "description": "Get file objects.",
-            "operationId": "getFileObject",
+            "description": "Retrieves the contents of a file from a specified path.",
+            "operationId": "getFileContents",
             "parameters": [
                 {
-                    "description": "File path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FilePath",
                     "required": true,
@@ -567,12 +564,6 @@
                     "description": "Returns only files that were not modified since the specified time. If there are no unmodified files since this time, a 412 message is returned to indicate that the precondition failed.",
                     "in": "header",
                     "name": "If-Unmodified-Since",
-                    "type": "string"
-                },
-                {
-                    "description": "Show object metadata.",
-                    "in": "query",
-                    "name": "metadata",
                     "type": "string"
                 }
             ],
@@ -597,11 +588,11 @@
             ]
         },
         "head": {
-            "description": "Get attribute information for file.",
+            "description": "Retrieves the attribute information for a specified file.",
             "operationId": "getFileAttributes",
             "parameters": [
                 {
-                    "description": "File path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FilePath",
                     "required": true,
@@ -641,11 +632,11 @@
             ]
         },
         "put": {
-            "description": "Create file object.",
+            "description": "Creates a file object with a given path.",
             "operationId": "createFile",
             "parameters": [
                 {
-                    "description": "File path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FilePath",
                     "required": true,
@@ -660,9 +651,23 @@
                     "type": "string"
                 },
                 {
+                    "default": "0600",
                     "description": "Specifies a pre-defined ACL value or POSIX mode with a string in octal string format.",
                     "in": "header",
                     "name": "x-isi-ifs-access-control",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the content encoding that was applied to the object content, so that decoding can be applied when retrieving the content.",
+                    "in": "header",
+                    "name": "Content-Encoding",
+                    "type": "string"
+                },
+                {
+                    "default": "binary/octet-stream",
+                    "description": "Specifies a standard MIME-type description of the content format.",
+                    "in": "header",
+                    "name": "Content-Type",
                     "type": "string"
                 },
                 {
@@ -672,6 +677,7 @@
                     "type": "boolean"
                 },
                 {
+                    "description": "The contents of the file object.",
                     "in": "body",
                     "name": "FileContents",
                     "required": true
@@ -690,11 +696,11 @@
             ]
         },
         "post": {
-            "description": "Move file.",
+            "description": "Moves a file to a destination path that does not yet exist.",
             "operationId": "moveFile",
             "parameters": [
                 {
-                    "description": "File path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FilePath",
                     "required": true,
@@ -721,11 +727,11 @@
             ]
         },
         "delete": {
-            "description": "Delete file.",
+            "description": "Deletes the specified file.",
             "operationId": "deleteFile",
             "parameters": [
                 {
-                    "description": "File path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FilePath",
                     "required": true,
@@ -734,7 +740,10 @@
             ],
             "responses": {
                 "204": {
-                    "description": "Deleted file."
+                    "description": "Deleted file.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
                 }
             },
             "tags": [
@@ -744,11 +753,11 @@
     },
     "/namespace/{FileCopyDestination}": {
         "put": {
-            "description": "Copy file.",
+            "description": "Copies a file to the specified destination path.",
             "operationId": "copyFile",
             "parameters": [
                 {
-                    "description": "File copy destination.",
+                    "description": "File copy destination relative to /.",
                     "in": "path",
                     "name": "FileCopyDestination",
                     "required": true,
@@ -795,11 +804,11 @@
     },
     "/namespace/{FileMetadataPath}": {
         "get": {
-            "description": "List metadata on a file.",
-            "operationId": "listFileMetadata",
+            "description": "Retrieves the attribute information for a specified file with the metadata query argument.",
+            "operationId": "getFileMetadata",
             "parameters": [
                 {
-                    "description": "File metadata path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FileMetadataPath",
                     "required": true,
@@ -810,14 +819,14 @@
                     "in": "query",
                     "name": "metadata",
                     "required": true,
-                    "type": "string"
+                    "type": "boolean"
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "List file metadata.",
+                    "description": "Get file metadata.",
                     "schema": {
-                        "$ref": "#/definitions/ObjectMetadataList"
+                        "$ref": "#/definitions/NamespaceMetadataList"
                     }
                 }
             },
@@ -826,11 +835,11 @@
             ]
         },
         "put": {
-            "description": "Set metadata on a file.",
+            "description": "Sets attributes on a specified file with the metadata query argument through the JSON body.",
             "operationId": "setFileMetadata",
             "parameters": [
                 {
-                    "description": "File metadata path.",
+                    "description": "File path relative to /.",
                     "in": "path",
                     "name": "FileMetadataPath",
                     "required": true,
@@ -841,17 +850,15 @@
                     "in": "query",
                     "name": "metadata",
                     "required": true,
-                    "schema": {
-                        "default": "",
-                        "type": "string"
-                    }
+                    "type": "boolean"
                 },
                 {
+                    "description": "File metadata parameters model.",
                     "in": "body",
                     "name": "FileMetadata",
                     "required": true,
                     "schema": {
-                        "$ref": "#/definitions/ObjectMetadata"
+                        "$ref": "#/definitions/NamespaceMetadata"
                     }
                 }
             ],
@@ -868,31 +875,91 @@
             ]
         }
     },
-    "/namespace/{ObjectAcl}": {
-        "get": {
-            "description": "Get object ACL.",
-            "operationId": "getObjectAcl",
+    "/namespace/{QueryPath}": {
+        "post": {
+            "description": "Query objects by system-defined and user-defined attributes in a directory.",
+            "operationId": "queryDirectory",
             "parameters": [
                 {
-                    "description": "Object path.",
+                    "description": "Directory path relative to /.",
                     "in": "path",
-                    "name": "ObjectAcl",
+                    "name": "QueryPath",
                     "required": true,
                     "type": "string"
                 },
                 {
-                    "description": "Show access control lists.",
+                    "description": "Enable directory query.",
                     "in": "query",
-                    "name": "acl",
+                    "name": "query",
                     "required": true,
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies the maximum number of objects to send to the client. You can set the value to a negative number to retrieve all objects.",
+                    "in": "query",
+                    "name": "limit",
+                    "type": "integer"
+                },
+                {
+                    "description": "Specifies which object attributes are displayed. If the detail parameter is excluded, only the name of the object is returned.",
+                    "in": "query",
+                    "name": "detail",
                     "type": "string"
+                },
+                {
+                    "description": "Specifies the maximum directory level depth to search for objects.",
+                    "in": "query",
+                    "name": "max-depth",
+                    "type": "integer"
+                },
+                {
+                    "description": "Directory query parameters model.",
+                    "in": "body",
+                    "name": "DirectoryQuery",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/DirectoryQuery"
+                    }
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Get object ACL.",
+                    "description": "Directory query results.",
                     "schema": {
-                        "$ref": "#/definitions/NamespaceAccessPoint"
+                        "$ref": "#/definitions/NamespaceObjects"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{WormFilePath}": {
+        "get": {
+            "description": "Retrieves the WORM retention date and committed state of the file.",
+            "operationId": "getWormProperties",
+            "parameters": [
+                {
+                    "description": "Write once read many file path relative to /.",
+                    "in": "path",
+                    "name": "WormFilePath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "View WORM properties",
+                    "in": "query",
+                    "name": "worm",
+                    "required": true,
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "WORM file properties.",
+                    "schema": {
+                        "$ref": "#/definitions/WormProperties"
                     }
                 }
             },
@@ -901,35 +968,36 @@
             ]
         },
         "put": {
-            "description": "Set object ACL.",
-            "operationId": "setObjectAcl",
+            "description": "Sets the retention period and commits a file in a SmartLock directory.",
+            "operationId": "setWormProperties",
             "parameters": [
                 {
-                    "description": "Object path.",
+                    "description": "Write once read many file path relative to /.",
                     "in": "path",
-                    "name": "ObjectAcl",
+                    "name": "WormFilePath",
                     "required": true,
                     "type": "string"
                 },
                 {
-                    "description": "Update access control lists.",
+                    "description": "View WORM properties",
                     "in": "query",
-                    "name": "acl",
+                    "name": "worm",
                     "required": true,
-                    "type": "string"
+                    "type": "boolean"
                 },
                 {
+                    "description": "WORM parameters model.",
                     "in": "body",
-                    "name": "ObjectAclBody",
+                    "name": "WormProperties",
                     "required": true,
                     "schema": {
-                        "$ref": "#/definitions/NamespaceAccessPoint"
+                        "$ref": "#/definitions/WormCreateParams"
                     }
                 }
             ],
             "responses": {
                 "200": {
-                    "description": "Set object ACL.",
+                    "description": "WORM file properties.",
                     "schema": {
                         "$ref": "#/definitions/Empty"
                     }

--- a/papi_schemas/namespace.json
+++ b/papi_schemas/namespace.json
@@ -1,0 +1,943 @@
+{
+    "/namespace": {
+        "get": {
+            "description": "List namespace access points.",
+            "operationId": "listAccessPoints",
+            "parameters": [
+                {
+                    "description": "Protocol versions that are supported for the current namespace access server.",
+                    "in": "query",
+                    "name": "versions",
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "List namespace access points.",
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceAccessPoints"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{AccessPoint}": {
+        "put": {
+            "description": "Create access point.",
+            "operationId": "createAccessPoint",
+            "parameters": [
+                {
+                    "description": "Access point path.",
+                    "in": "path",
+                    "name": "AccessPoint",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "in": "body",
+                    "name": "AccessPointPath",
+                    "required": true,
+                    "schema": {
+                        "properties": {
+                            "path": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Created access point."
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "delete": {
+            "description": "Delete access point.",
+            "operationId": "deleteAccessPoint",
+            "parameters": [
+                {
+                    "description": "Access point path.",
+                    "in": "path",
+                    "name": "AccessPoint",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Deleted access point."
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{AccessPointAcl}": {
+        "get": {
+            "description": "Get access point ACL.",
+            "operationId": "getAccessPointAcl",
+            "parameters": [
+                {
+                    "description": "Access point path.",
+                    "in": "path",
+                    "name": "AccessPointAcl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Show access control lists.",
+                    "in": "query",
+                    "name": "acl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Indicates that the operation is on the access point instead of the store path.",
+                    "in": "query",
+                    "name": "nsaccess",
+                    "required": true,
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Get access point ACL.",
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceAccessPoint"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Set access point ACL.",
+            "operationId": "setAccessPointAcl",
+            "parameters": [
+                {
+                    "description": "Access point path.",
+                    "in": "path",
+                    "name": "AccessPointAcl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Update access control lists.",
+                    "in": "query",
+                    "name": "acl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Indicates that the operation is on the access point instead of the store path.",
+                    "in": "query",
+                    "name": "nsaccess",
+                    "required": true,
+                    "type": "boolean"
+                },
+                {
+                    "in": "body",
+                    "name": "AccessPointAclBody",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceAccessPoint"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Set access point ACL.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{DirectoryPath}": {
+        "get": {
+            "description": "List directory objects.",
+            "operationId": "listDirectoryObjects",
+            "parameters": [
+                {
+                    "description": "Directory path.",
+                    "in": "path",
+                    "name": "DirectoryPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies which object attributes are displayed.",
+                    "in": "query",
+                    "name": "detail",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the maximum number of objects to send to the client.",
+                    "in": "query",
+                    "name": "limit",
+                    "type": "integer"
+                },
+                {
+                    "description": "Specifies a token to return in the JSON result to indicate when there is a next page.",
+                    "in": "query",
+                    "name": "resume",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies one or more attributes to sort on the directory entries.",
+                    "in": "query",
+                    "name": "sort",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the sort direction. This value can be either ascending (ASC) or descending (DESC).",
+                    "in": "query",
+                    "name": "dir",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the object type to return, which can be one of the following values: container, object, pipe, character_device, block_device, symbolic_link, socket, or whiteout_file.",
+                    "in": "query",
+                    "name": "type",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies if hidden objects are returned.",
+                    "in": "query",
+                    "name": "hidden",
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "List directory objects.",
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceObjects"
+                    }
+                },
+                "headers": {
+                    "x-isi-ifs-missing-attr": {
+                        "type": "string"
+                    },
+                    "x-isi-ifs-access-control": {
+                        "type": "string"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "head": {
+            "description": "Get attribute information for directory.",
+            "operationId": "getDirectoryAttributes",
+            "parameters": [
+                {
+                    "description": "Directory path.",
+                    "in": "path",
+                    "name": "DirectoryPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were modified since the specified time. If no files were modified since this time, a 304 message is returned.",
+                    "in": "header",
+                    "name": "If-Modified-Since",
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were not modified since the specified time. If there are no unmodified files since this time, a 412 message is returned to indicate that the precondition failed.",
+                    "in": "header",
+                    "name": "If-Unmodified-Since",
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Get attribute information for directory.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                        "x-isi-ifs-access-control": {
+                            "type": "string"
+                        },
+                        "x-isi-ifs-spec-version": {
+                            "type": "string"
+                        },
+                        "x-isi-ifs-missing-attr": {
+                            "type": "string"
+                        },
+                        "x-isi-ifs-target-type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Create directory.",
+            "operationId": "createDirectory",
+            "parameters": [
+                {
+                    "description": "Directory path.",
+                    "in": "path",
+                    "name": "DirectoryPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the resource type.",
+                    "in": "header",
+                    "name": "x-isi-ifs-target-type",
+                    "required": true,
+                    "default": "container",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies a pre-defined ACL value or POSIX mode with a string in octal string format.",
+                    "in": "header",
+                    "name": "x-isi-ifs-access-control",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies a pre-defined ACL value or POSIX mode with a string.",
+                    "in": "header",
+                    "name": "x-isi-ifs-node-pool-name",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the OneFS node pool name.",
+                    "in": "query",
+                    "name": "recursive",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Deletes and replaces the existing user attributes and ACLs of the directory with user-specified attributes and ACLS from the header, when set to true.",
+                    "in": "query",
+                    "name": "overwrite",
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Create directory.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "post": {
+            "description": "Move directory.",
+            "operationId": "moveDirectory",
+            "parameters": [
+                {
+                    "description": "Directory path.",
+                    "in": "path",
+                    "name": "DirectoryPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the full path for the destination directory.",
+                    "in": "header",
+                    "name": "x-isi-ifs-set-location",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Move directory.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "delete": {
+            "description": "Delete directory.",
+            "operationId": "deleteDirectory",
+            "parameters": [
+                {
+                    "description": "Directory path.",
+                    "in": "path",
+                    "name": "DirectoryPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Deletes directories recursively, when set to true.",
+                    "in": "query",
+                    "name": "recursive",
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "204": {
+                    "description": "Deleted directory."
+                },
+                "default": {
+                    "description": "Unexpected error",
+                    "schema": {
+                        "$ref": "#/definitions/Error"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{DirectoryMetadataPath}": {
+        "get": {
+            "description": "List metadata on a directory.",
+            "operationId": "listDirectoryMetadata",
+            "parameters": [
+                {
+                    "description": "Directory metadata path.",
+                    "in": "path",
+                    "name": "DirectoryMetadataPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Show directory metadata.",
+                    "in": "query",
+                    "name": "metadata",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "List directory metadata.",
+                    "schema": {
+                        "$ref": "#/definitions/ObjectMetadataList"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Set metadata on a directory.",
+            "operationId": "setDirectoryMetadata",
+            "parameters": [
+                {
+                    "description": "Directory metadata path.",
+                    "in": "path",
+                    "name": "DirectoryMetadataPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Set directory metadata.",
+                    "in": "query",
+                    "name": "metadata",
+                    "required": true,
+                    "schema": {
+                        "default": "",
+                        "type": "string"
+                    }
+                },
+                {
+                    "in": "body",
+                    "name": "DirectoryMetadata",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/ObjectMetadata"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Set metadata on directory.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{DirectoryCopyDestination}": {
+        "put": {
+            "description": "Copy directory.",
+            "operationId": "copyDirectory",
+            "parameters": [
+                {
+                    "description": "Directory copy destination.",
+                    "in": "path",
+                    "name": "DirectoryCopyDestination",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the full path to the source directory.",
+                    "in": "header",
+                    "name": "x-isi-ifs-copy-source",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Deletes and replaces the existing user attributes and ACLs of the directory with user-specified attributes and ACLS from the header, when set to true.",
+                    "in": "query",
+                    "name": "overwrite",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies if the contents of a directory should be merged with an existing directory with the same name.",
+                    "in": "query",
+                    "name": "merge",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies whether to continue the copy operation on remaining objects when there is a conflict or error.",
+                    "in": "query",
+                    "name": "continue",
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Copied directory.",
+                    "schema": {
+                        "$ref": "#/definitions/CopyErrors"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{FilePath}": {
+        "get": {
+            "description": "Get file objects.",
+            "operationId": "getFileObject",
+            "parameters": [
+                {
+                    "description": "File path.",
+                    "in": "path",
+                    "name": "FilePath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Returns the specified range bytes of an object. ",
+                    "in": "header",
+                    "name": "Range",
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were modified since the specified time. If no files were modified since this time, a 304 message is returned.",
+                    "in": "header",
+                    "name": "If-Modified-Since",
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were not modified since the specified time. If there are no unmodified files since this time, a 412 message is returned to indicate that the precondition failed.",
+                    "in": "header",
+                    "name": "If-Unmodified-Since",
+                    "type": "string"
+                },
+                {
+                    "description": "Show object metadata.",
+                    "in": "query",
+                    "name": "metadata",
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Get file objects.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                },
+                "headers": {
+                    "x-isi-ifs-missing-attr": {
+                        "type": "string"
+                    },
+                    "x-isi-ifs-access-control": {
+                        "type": "string"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "head": {
+            "description": "Get attribute information for file.",
+            "operationId": "getFileAttributes",
+            "parameters": [
+                {
+                    "description": "File path.",
+                    "in": "path",
+                    "name": "FilePath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were modified since the specified time. If no files were modified since this time, a 304 message is returned.",
+                    "in": "header",
+                    "name": "If-Modified-Since",
+                    "type": "string"
+                },
+                {
+                    "description": "Returns only files that were not modified since the specified time. If there are no unmodified files since this time, a 412 message is returned to indicate that the precondition failed.",
+                    "in": "header",
+                    "name": "If-Unmodified-Since",
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Get attribute information for file.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                        "x-isi-ifs-access-control": {
+                            "type": "string"
+                        },
+                        "x-isi-ifs-missing-attr": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Create file object.",
+            "operationId": "createFile",
+            "parameters": [
+                {
+                    "description": "File path.",
+                    "in": "path",
+                    "name": "FilePath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the resource type.",
+                    "in": "header",
+                    "name": "x-isi-ifs-target-type",
+                    "required": true,
+                    "default": "object",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies a pre-defined ACL value or POSIX mode with a string in octal string format.",
+                    "in": "header",
+                    "name": "x-isi-ifs-access-control",
+                    "type": "string"
+                },
+                {
+                    "description": "Deletes and replaces the existing user attributes and ACLs of the directory with user-specified attributes and ACLS from the header, when set to true.",
+                    "in": "query",
+                    "name": "overwrite",
+                    "type": "boolean"
+                },
+                {
+                    "in": "body",
+                    "name": "FileContents",
+                    "required": true
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Created file object.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "post": {
+            "description": "Move file.",
+            "operationId": "moveFile",
+            "parameters": [
+                {
+                    "description": "File path.",
+                    "in": "path",
+                    "name": "FilePath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the full path for the destination file. ",
+                    "in": "header",
+                    "name": "x-isi-ifs-set-location",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Moved file.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "delete": {
+            "description": "Delete file.",
+            "operationId": "deleteFile",
+            "parameters": [
+                {
+                    "description": "File path.",
+                    "in": "path",
+                    "name": "FilePath",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "204": {
+                    "description": "Deleted file."
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{FileCopyDestination}": {
+        "put": {
+            "description": "Copy file.",
+            "operationId": "copyFile",
+            "parameters": [
+                {
+                    "description": "File copy destination.",
+                    "in": "path",
+                    "name": "FileCopyDestination",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the full path to the source file.",
+                    "in": "header",
+                    "name": "x-isi-ifs-copy-source",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "You must set this parameter to true in order to clone a file.",
+                    "in": "query",
+                    "name": "clone",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies a snapshot name to clone the file from.",
+                    "in": "query",
+                    "name": "snapshot",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies if an existing file should be overwritten by a new file with the same name.",
+                    "in": "query",
+                    "name": "overwrite",
+                    "type": "boolean"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Copied file.",
+                    "schema": {
+                        "$ref": "#/definitions/CopyErrors"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{FileMetadataPath}": {
+        "get": {
+            "description": "List metadata on a file.",
+            "operationId": "listFileMetadata",
+            "parameters": [
+                {
+                    "description": "File metadata path.",
+                    "in": "path",
+                    "name": "FileMetadataPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Show file metadata.",
+                    "in": "query",
+                    "name": "metadata",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "List file metadata.",
+                    "schema": {
+                        "$ref": "#/definitions/ObjectMetadataList"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Set metadata on a file.",
+            "operationId": "setFileMetadata",
+            "parameters": [
+                {
+                    "description": "File metadata path.",
+                    "in": "path",
+                    "name": "FileMetadataPath",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Set file metadata.",
+                    "in": "query",
+                    "name": "metadata",
+                    "required": true,
+                    "schema": {
+                        "default": "",
+                        "type": "string"
+                    }
+                },
+                {
+                    "in": "body",
+                    "name": "FileMetadata",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/ObjectMetadata"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Set metadata on file.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    },
+    "/namespace/{ObjectAcl}": {
+        "get": {
+            "description": "Get object ACL.",
+            "operationId": "getObjectAcl",
+            "parameters": [
+                {
+                    "description": "Object path.",
+                    "in": "path",
+                    "name": "ObjectAcl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Show access control lists.",
+                    "in": "query",
+                    "name": "acl",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Get object ACL.",
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceAccessPoint"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        },
+        "put": {
+            "description": "Set object ACL.",
+            "operationId": "setObjectAcl",
+            "parameters": [
+                {
+                    "description": "Object path.",
+                    "in": "path",
+                    "name": "ObjectAcl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "description": "Update access control lists.",
+                    "in": "query",
+                    "name": "acl",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "in": "body",
+                    "name": "ObjectAclBody",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/NamespaceAccessPoint"
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "Set object ACL.",
+                    "schema": {
+                        "$ref": "#/definitions/Empty"
+                    }
+                }
+            },
+            "tags": [
+                "Namespace"
+            ]
+        }
+    }
+}

--- a/papi_schemas/namespace.json
+++ b/papi_schemas/namespace.json
@@ -229,14 +229,6 @@
                     "schema": {
                         "$ref": "#/definitions/NamespaceObjects"
                     }
-                },
-                "headers": {
-                    "x-isi-ifs-missing-attr": {
-                        "type": "string"
-                    },
-                    "x-isi-ifs-access-control": {
-                        "type": "string"
-                    }
                 }
             },
             "tags": [
@@ -272,20 +264,6 @@
                     "description": "Get attribute information for directory.",
                     "schema": {
                         "$ref": "#/definitions/Empty"
-                    },
-                    "headers": {
-                        "x-isi-ifs-access-control": {
-                            "type": "string"
-                        },
-                        "x-isi-ifs-spec-version": {
-                            "type": "string"
-                        },
-                        "x-isi-ifs-missing-attr": {
-                            "type": "string"
-                        },
-                        "x-isi-ifs-target-type": {
-                            "type": "string"
-                        }
                     }
                 }
             },
@@ -573,14 +551,6 @@
                     "schema": {
                         "$ref": "#/definitions/Empty"
                     }
-                },
-                "headers": {
-                    "x-isi-ifs-missing-attr": {
-                        "type": "string"
-                    },
-                    "x-isi-ifs-access-control": {
-                        "type": "string"
-                    }
                 }
             },
             "tags": [
@@ -616,14 +586,6 @@
                     "description": "Get attribute information for file.",
                     "schema": {
                         "$ref": "#/definitions/Empty"
-                    },
-                    "headers": {
-                        "x-isi-ifs-access-control": {
-                            "type": "string"
-                        },
-                        "x-isi-ifs-missing-attr": {
-                            "type": "string"
-                        }
                     }
                 }
             },
@@ -680,7 +642,10 @@
                     "description": "The contents of the file object.",
                     "in": "body",
                     "name": "FileContents",
-                    "required": true
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
                 }
             ],
             "responses": {

--- a/papi_schemas/namespace.json
+++ b/papi_schemas/namespace.json
@@ -86,7 +86,7 @@
     "/namespace/{NamespacePath}": {
         "get": {
             "description": "Retrieves the access control list for a namespace object.",
-            "operationId": "getNamespaceAcl",
+            "operationId": "getAcl",
             "parameters": [
                 {
                     "description": "Namespace path relative to /.",
@@ -123,7 +123,7 @@
         },
         "put": {
             "description": "Sets the access control list for a namespace.",
-            "operationId": "setNamespaceAcl",
+            "operationId": "setAcl",
             "parameters": [
                 {
                     "description": "Namespace path relative to /.",
@@ -485,7 +485,7 @@
             ]
         }
     },
-    "/namespace/{DirectoryCopyDestination}": {
+    "/namespace/{DirectoryCopyTarget}": {
         "put": {
             "description": "Recursively copies a directory to a specified destination path. Symbolic links are copied as regular files.",
             "operationId": "copyDirectory",
@@ -493,7 +493,7 @@
                 {
                     "description": "Directory copy destination relative to /.",
                     "in": "path",
-                    "name": "DirectoryCopyDestination",
+                    "name": "DirectoryCopyTarget",
                     "required": true,
                     "type": "string"
                 },
@@ -538,7 +538,7 @@
     },
     "/namespace/{FilePath}": {
         "get": {
-            "description": "Retrieves the contents of a file from a specified path.",
+            "description": "Retrieves the contents of a file from a specified path. Note that file streaming is not supported.",
             "operationId": "getFileContents",
             "parameters": [
                 {
@@ -632,7 +632,7 @@
             ]
         },
         "put": {
-            "description": "Creates a file object with a given path.",
+            "description": "Creates a file object with a given path. Note that file streaming is not supported.",
             "operationId": "createFile",
             "parameters": [
                 {
@@ -751,7 +751,7 @@
             ]
         }
     },
-    "/namespace/{FileCopyDestination}": {
+    "/namespace/{FileCopyTarget}": {
         "put": {
             "description": "Copies a file to the specified destination path.",
             "operationId": "copyFile",
@@ -759,7 +759,7 @@
                 {
                     "description": "File copy destination relative to /.",
                     "in": "path",
-                    "name": "FileCopyDestination",
+                    "name": "FileCopyTarget",
                     "required": true,
                     "type": "string"
                 },

--- a/readme.dev.md
+++ b/readme.dev.md
@@ -1,7 +1,7 @@
 # Isilon Software Development Kit (isi-sdk)
 Building language bindings using the OpenAPI config generator
 
-This document describes how to use the scripts in the isi-sdk repository to generate your own language bindings for the Isilon OneFS configuration API.  This API is made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or PAPI".
+This document describes how to use the scripts in the isilon_sdk repository to generate your own language bindings for the Isilon OneFS configuration API.  This API is made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or "PAPI".  This API also includes the URIs underneath `https://[cluster]:8080/namespace/*`, also called the "RESTful Access to Namespace" or "RAN".
 
 The scripts create a configuration file compatible with the OpenAPI Specification (formerly known as swagger, and we will continue to call the configuration file the "swagger config" here for now).  More info about the OpenAPI Specification [here](https://github.com/OAI/OpenAPI-Specification).
 

--- a/readme.pypi.md
+++ b/readme.pypi.md
@@ -1,5 +1,5 @@
 ## About
-This package is part of the Isilon SDK.  It includes language bindings for easier programmatic access to the OneFS API for cluster configuration (on your cluster this is the REST API made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or "PAPI").
+This package is part of the Isilon SDK.  It includes language bindings for easier programmatic access to the OneFS API for cluster configuration (on your cluster this is the REST API made up of all the URIs underneath `https://[cluster]:8080/platform/*`, also called the "Platform API" or "PAPI").  The SDK also includes language bindings for the OneFS RAN (i.e. RESTful Access to Namespace) interface, which provides access to the OneFS filesystem namespace.
 
 ## Installation
 

--- a/swagger_templates/python/api_client.mustache
+++ b/swagger_templates/python/api_client.mustache
@@ -543,7 +543,7 @@ class ApiClient(object):
             body = {
                 'username': self.configuration.username,
                 'password': self.configuration.password,
-                'services': ['platform']
+                'services': ['platform', 'namespace']
             }
             response_data = self.rest_client.POST(
                 url, headers=headers, body=body)

--- a/tests/test_access_points.py
+++ b/tests/test_access_points.py
@@ -1,0 +1,67 @@
+"""Access points with isi_sdk.NamespaceApi."""
+import urllib3
+
+import isi_sdk_8_1_1 as isi_sdk
+
+import test_constants
+
+urllib3.disable_warnings()
+
+
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
+
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    api = isi_sdk.NamespaceApi(api_client)
+    auth_api = isi_sdk.AuthApi(api_client)
+
+    # get list of access points
+    print('Access points: {}'.format(api.list_access_points().namespaces))
+
+    # get list of access point versions
+    versions = api.list_access_points(versions=True).versions
+    print('Protocol versions of namespace access server: {}'.format(versions))
+
+    # create access point
+    ap_path = isi_sdk.AccessPointCreateParams(path='/ifs/home')
+    api.create_access_point('user1', access_point=ap_path)
+    print('Access points: {}'.format(api.list_access_points().namespaces))
+
+    # create test user
+    auth_user = isi_sdk.AuthUserCreateParams(
+        name='user1', password='user1', home_directory='/ifs/home/user1')
+    auth_api.create_auth_user(auth_user)
+
+    # set ACL for user
+    acl_body = isi_sdk.NamespaceAcl(
+        authoritative='acl',
+        acl=[
+            isi_sdk.AclObject(
+                trustee={'name': 'user1', 'type': 'user'},
+                accesstype='allow',
+                accessrights=['file_read'],
+                op='add'
+            )
+        ]
+    )
+    api.set_acl('user1', acl=True, nsaccess=True, namespace_acl=acl_body)
+
+    # get access control list
+    print('ACL: {}'.format(api.get_acl('user1', acl=True, nsaccess=True)))
+
+    # clean up test access point
+    api.delete_access_point('user1')
+    # clean up test user
+    auth_api.delete_auth_user('user1')
+    api.delete_directory('ifs/home/user1', recursive=True)
+    print('Successful clean up')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_namespace_directories.py
+++ b/tests/test_namespace_directories.py
@@ -1,0 +1,128 @@
+"""Directories with isi_sdk.NamespaceApi."""
+import urllib3
+
+import isi_sdk_8_1_1 as isi_sdk
+
+import test_constants
+
+urllib3.disable_warnings()
+
+
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
+
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    api = isi_sdk.NamespaceApi(api_client)
+
+    # create a directory
+    api.create_directory(
+        'ifs/ns_src/ns_dir', x_isi_ifs_target_type='container',
+        recursive=True, overwrite=True)
+
+    # recursively copy directory from /ifs/ns_src to /ifs/ns_dest
+    api.copy_directory(
+        'ifs/ns_dest', x_isi_ifs_copy_source='/namespace/ifs/ns_src',
+        merge=True)
+    print('Copied directory: {}'.format(
+        api.get_directory_contents('ifs/ns_dest').children[0].name))
+    api.delete_directory('ifs/ns_dest', recursive=True)
+
+    # move directory from /ifs/ns_src to /ifs/ns_dest
+    api.move_directory(
+        'ifs/ns_src', x_isi_ifs_set_location='/namespace/ifs/ns_dest')
+    print('Moved directory: {}'.format(
+        api.get_directory_contents('ifs/ns_dest').children[0].name))
+    api.delete_directory('ifs/ns_dest', recursive=True)
+
+    # get directory attributes from response headers
+    sdk_resp = api.get_directory_attributes_with_http_info('ifs/data')
+    # the third index of the response is the response headers
+    print('Directory attributes from headers: {}'.format(sdk_resp[2]))
+
+    # get default directory detail
+    details = api.get_directory_contents(
+        'ifs', detail='default').children[0].to_dict()
+    for key, val in details.items():
+        if val is None:
+            del details[key]
+    print('Default directory details: {}'.format(details))
+    # get directory last modified time
+    print('Last modified time: {}'.format(
+        api.get_directory_contents(
+            'ifs', detail='last_modified').children[0].last_modified))
+
+    # use resume token to paginate requests
+    resume = api.get_directory_contents('ifs', limit=3).resume
+    api.get_directory_contents('ifs', resume=resume)
+
+    # get extended attributes on a directory
+    print('Directory metadata attributes: {}'.format(
+        api.get_directory_metadata('ifs', metadata=True)))
+    # create extended attribute
+    meta = isi_sdk.NamespaceMetadata(
+        action='update',
+        attrs=[isi_sdk.NamespaceMetadataAttrs(
+            name='test', value='42', op='update', namespace='user')])
+    # set extended attribute on a directory
+    api.set_directory_metadata('ifs', metadata=True, directory_metadata=meta)
+    # remove extended attribute
+    meta = isi_sdk.NamespaceMetadata(
+        action='update',
+        attrs=[isi_sdk.NamespaceMetadataAttrs(
+            name='test', value='42', op='delete', namespace='user')])
+    api.set_directory_metadata('ifs', metadata=True, directory_metadata=meta)
+
+    # set access control list on a directory
+    test_dir = 'ifs/ns_src'
+    api.create_directory(
+        test_dir, x_isi_ifs_target_type='container',
+        x_isi_ifs_access_control='0770')
+    print('Directory ACL: {}'.format(api.get_acl(test_dir, acl=True)))
+
+    # give everyone read permissions on the directory
+    acl_body = isi_sdk.NamespaceAcl(authoritative='mode', mode='0444')
+    api.set_acl(test_dir, acl=True, namespace_acl=acl_body)
+    print('Set directory permissions: {}'.format(
+        api.get_acl(test_dir, acl=True).mode))
+    api.delete_directory(test_dir)
+
+    # build directory query
+    query = isi_sdk.DirectoryQuery(
+        result=['name', 'size', 'last_modified', 'owner'],
+        scope=isi_sdk.DirectoryQueryScope(
+            logic='and',
+            conditions=[
+                isi_sdk.DirectoryQueryScopeConditions(
+                    operator='>=',
+                    attr='last_modified',
+                    value="Thu, 15 Dec 2011 06:41:04"
+                ),
+                isi_sdk.DirectoryQueryScopeConditions(
+                    operator='>=',
+                    attr='size',
+                    value=1000
+                )
+            ]
+        )
+    )
+    # exhaustive list of optional details
+    details = (
+        'access_time,atime_val,block_size,blocks,btime_val,'
+        'change_time,create_time,ctime_val,gid,group,id,'
+        'is_hidden,mode,mtime_val,nlink,stub,type,uid')
+    # execute directory query
+    query_resp = api.query_directory(
+        'ifs/data', query=True, directory_query=query, detail=details,
+        max_depth=2, limit=2)
+    print('Query results for /ifs/data: {}'.format(query_resp))
+    print('Successful clean up')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_namespace_files.py
+++ b/tests/test_namespace_files.py
@@ -1,0 +1,89 @@
+"""Files with isi_sdk.NamespaceApi."""
+import urllib3
+
+import isi_sdk_8_1_1 as isi_sdk
+
+import test_constants
+
+urllib3.disable_warnings()
+
+
+def main():
+    # configure username and password
+    configuration = isi_sdk.Configuration()
+    configuration.username = test_constants.USERNAME
+    configuration.password = test_constants.PASSWORD
+    configuration.verify_ssl = test_constants.VERIFY_SSL
+    configuration.host = test_constants.HOST
+
+    # configure client connection
+    api_client = isi_sdk.ApiClient(configuration)
+    api = isi_sdk.NamespaceApi(api_client)
+
+    # create a file
+    contents = 'Lorem ipsum dolor sit amet, est eu nobis volutpat maluisset.'
+    api.create_file(
+        'ifs/data/lorem', x_isi_ifs_target_type='object',
+        file_contents=contents, x_isi_ifs_access_control='600')
+    # fetch file contents
+    print('File contents: {}'.format(api.get_file_contents('ifs/data/lorem')))
+
+    # copy file /ifs/data/lorem to /ifs/data/ipsum
+    api.copy_file(
+        'ifs/data/ipsum', x_isi_ifs_copy_source='/namespace/ifs/data/lorem')
+    api.delete_file('ifs/data/ipsum')
+
+    # clone file /ifs/data/lorem to /ifs/data/ipsum
+    api.copy_file(
+        'ifs/data/ipsum', x_isi_ifs_copy_source='/namespace/ifs/data/lorem',
+        clone=True, overwrite=True)
+    api.delete_file('ifs/data/ipsum')
+
+    # move file /ifs/data/lorem to /ifs/data/ipsum
+    api.move_file(
+        'ifs/data/lorem', x_isi_ifs_set_location='/namespace/ifs/data/ipsum')
+
+    # set extended attribute on a file
+    print(api.get_file_metadata('ifs/data/ipsum', metadata=True))
+
+    # create extended attribute
+    meta = isi_sdk.NamespaceMetadata(
+        action='update',
+        attrs=[isi_sdk.NamespaceMetadataAttrs(
+            name='test', value='42', op='update', namespace='user')])
+    api.set_file_metadata(
+        'ifs/data/ipsum', metadata=True, file_metadata=meta)
+
+    # assert that extended attribute value was set
+    for attr in api.get_file_metadata(
+            'ifs/data/ipsum', metadata=True).attrs:
+        if attr.name == 'test':
+            print('Extended attribute was set: {}'.format(attr.value == '42'))
+
+    attrs = api.get_file_attributes_with_http_info('ifs/data/ipsum')
+    # the third index of the response is the response headers
+    print('File attribute headers: {}'.format(attrs[2]))
+    api.delete_file('ifs/data/ipsum')
+
+    # set access control list on a file
+    api.create_file(
+        'ifs/data/lorem', x_isi_ifs_target_type='object',
+        x_isi_ifs_access_control='private_read',
+        file_contents='Lorem ipsum dolor sit amet.')
+
+    # get current file permissions
+    acl = api.get_acl('ifs/data/lorem', acl=True)
+    print('ACL mode is {}'.format(acl.mode))
+
+    # modify file permissions
+    acl_body = isi_sdk.NamespaceAcl(authoritative='mode', mode='0555')
+    api.set_acl('ifs/data/lorem', acl=True, namespace_acl=acl_body)
+    acl = api.get_acl('ifs/data/lorem', acl=True)
+    print('New ACL mode is {}'.format(acl.mode))
+
+    api.delete_file('ifs/data/lorem')
+    print('Successful clean up')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
This PR introduces support for the RAN interface to the Isilon SDK and resolves issue https://github.com/Isilon/isilon_sdk/issues/39.

Most of the content in the `namespace.json` and `definitions.json` files came from the official File System Access documentation, which is located [here](http://doc.isilon.com/onefs/8.1.0/api/04-ifs-br-file-system-access-apis.htm).

While the semantics and the required parameters of the namespace API cannot be changed by the SDK, the method names that are used to map to these resources can be changed. Thus, I have provided a list of methods that are currently being generated for the NamespaceApi class:

## Access point methods
```
def create_access_point(self, access_point_name, access_point, **kwargs):
def list_access_points(self, **kwargs):
def delete_access_point(self, access_point_name, **kwargs): 
```
## Directory methods
```
def create_directory(self, directory_path, x_isi_ifs_target_type, **kwargs):
def get_directory_contents(self, directory_path, **kwargs):
def get_directory_attributes(self, directory_path, **kwargs):
def copy_directory(self, directory_copy_target, x_isi_ifs_copy_source, **kwargs)
def move_directory(self, directory_path, x_isi_ifs_set_location, **kwargs):
def delete_directory(self, directory_path, **kwargs):

def get_directory_metadata(self, directory_metadata_path, metadata, **kwargs):
def set_directory_metadata(self, directory_metadata_path, metadata, directory_metadata, **kwargs):

def query_directory(self, query_path, query, directory_query, **kwargs): 
```
## File methods
```
def create_file(self, file_path, x_isi_ifs_target_type, file_contents, **kwargs): 
def get_file_contents(self, file_path, **kwargs):
def get_file_attributes(self, file_path, **kwargs):
def copy_file(self, file_copy_target, x_isi_ifs_copy_source, **kwargs):
def move_file(self, file_path, x_isi_ifs_set_location, **kwargs): 
def delete_file(self, file_path, **kwargs):

def get_file_metadata(self, file_metadata_path, metadata, **kwargs):
def set_file_metadata(self, file_metadata_path, metadata, file_metadata, **kwargs):

def get_worm_properties(self, worm_file_path, worm, **kwargs):
def set_worm_properties(self, worm_file_path, worm, worm_properties, **kwargs):
```
## Access control list methods
```
def set_acl(self, namespace_path, acl, namespace_acl, **kwargs):
def get_acl(self, namespace_path, acl, **kwargs): 
```
## Testing
A TDD strategy was employed when generating the language binds. This allowed the generated code to receive 90% test coverage.