### PR TITLE
Add missing container and container_path attributes

### DIFF
--- a/papi_schemas/definitions.json
+++ b/papi_schemas/definitions.json
@@ -159,7 +159,16 @@
                 "type": "boolean"
             },
             "stub": {
+                "description": "Specifies whether the file is a stub or not.",
                 "type": "boolean"
+            },
+            "container_path": {
+                "description": "Specifies the container path on the file system.",
+                "type": "string"
+            },
+            "container": {
+                "description": "Specifies the name of the queried container.",
+                "type": "string"
             }
         },
         "type": "object"

--- a/tests/test_namespace_directories.py
+++ b/tests/test_namespace_directories.py
@@ -48,9 +48,7 @@ def main():
     # get default directory detail
     details = api.get_directory_contents(
         'ifs', detail='default').children[0].to_dict()
-    for key, val in details.items():
-        if val is None:
-            del details[key]
+    details = dict((k, v) for k, v in details.items() if v)
     print('Default directory details: {}'.format(details))
     # get directory last modified time
     print('Last modified time: {}'.format(
@@ -115,7 +113,8 @@ def main():
     details = (
         'access_time,atime_val,block_size,blocks,btime_val,'
         'change_time,create_time,ctime_val,gid,group,id,'
-        'is_hidden,mode,mtime_val,nlink,stub,type,uid')
+        'is_hidden,mode,mtime_val,nlink,stub,type,uid,'
+        'container,container_path')
     # execute directory query
     query_resp = api.query_directory(
         'ifs/data', query=True, directory_query=query, detail=details,


### PR DESCRIPTION
This PR adds the `container` and `container_path` attributes to the Swagger `NamespaceObject` definition. The `container_path` attribute gives the absolute path of a file or directory on the file system, while the `container` attribute reports on the directory where a query was initiated from.