### PR TITLE
Add support for resume token on directory queries

### DIFF
--- a/papi_schemas/namespace.json
+++ b/papi_schemas/namespace.json
@@ -872,6 +872,36 @@
                     "type": "string"
                 },
                 {
+                    "description": "Specifies a token to return in the JSON result to indicate when there is a next page.",
+                    "in": "query",
+                    "name": "resume",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies one or more attributes to sort on the directory entries.",
+                    "in": "query",
+                    "name": "sort",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the sort direction. This value can be either ascending (ASC) or descending (DESC).",
+                    "in": "query",
+                    "name": "dir",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies the object type to return, which can be one of the following values: container, object, pipe, character_device, block_device, symbolic_link, socket, or whiteout_file.",
+                    "in": "query",
+                    "name": "type",
+                    "type": "string"
+                },
+                {
+                    "description": "Specifies if hidden objects are returned.",
+                    "in": "query",
+                    "name": "hidden",
+                    "type": "boolean"
+                },
+                {
                     "description": "Specifies the maximum directory level depth to search for objects.",
                     "in": "query",
                     "name": "max-depth",

--- a/tests/test_namespace_directories.py
+++ b/tests/test_namespace_directories.py
@@ -118,8 +118,15 @@ def main():
     # execute directory query
     query_resp = api.query_directory(
         'ifs/data', query=True, directory_query=query, detail=details,
-        max_depth=2, limit=2)
+        max_depth=2, limit=10)
     print('Query results for /ifs/data: {}'.format(query_resp))
+    # request remaining results in chunks
+    while query_resp.resume:
+        query_resp = api.query_directory(
+            'ifs/data', query=True, directory_query=query,
+            resume=query_resp.resume)
+        print('Resume query results: {}'.format(query_resp))
+
     print('Successful clean up')
 
 


### PR DESCRIPTION
This PR adds `resume`, `sort`, `dir`, `type`, and `hidden` has optional parameters for the `NamespaceApi.query_directory` method.