### PR TITLE
Account for dot versioned API endpoints

### DIFF
--- a/components/create_swagger_config.py
+++ b/components/create_swagger_config.py
@@ -1010,7 +1010,8 @@ def get_endpoint_paths(source_node_or_cluster, port, base_url, auth,
             next_endpoint = end_point_list_json[next_ep_index]
             # strip off the version and compare to see if they are
             # the same.
-            if next_endpoint[2:] != current_endpoint[2:]:
+            if (next_endpoint.split('/', 2)[-1] !=
+                    current_endpoint.split('/', 2)[-1]):
                 # using current_endpoint
                 break
             # skipping current_endpoint


### PR DESCRIPTION
The mechanism for comparing endpoints was assuming that the API version would always be a single digit with a length of 1. This is no longer a valid assumption when dealing with dot versioned endpoints, such as "3.1" which has a character length of 3. This issue is resolved by splitting on `/` instead.